### PR TITLE
Various improvements of data race analysis in Archer / ThreadSanitizer

### DIFF
--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -5019,13 +5019,16 @@ llvm::Function *CGOpenMPRuntime::emitReductionFunction(
   Args.push_back(&RHSArg);
   const auto &CGFI =
       CGM.getTypes().arrangeBuiltinFunctionDeclaration(C.VoidTy, Args);
+  CodeGenFunction CGF(CGM);
   std::string Name = getReductionFuncName(ReducerName);
   auto *Fn = llvm::Function::Create(CGM.getTypes().GetFunctionType(CGFI),
                                     llvm::GlobalValue::InternalLinkage, Name,
                                     &CGM.getModule());
+  if (CGF.SanOpts.has(SanitizerKind::Thread)) {
+    return Fn;
+  }
   CGM.SetInternalFunctionAttributes(GlobalDecl(), Fn, CGFI);
   Fn->setDoesNotRecurse();
-  CodeGenFunction CGF(CGM);
   CGF.StartFunction(GlobalDecl(), C.VoidTy, Fn, CGFI, Args, Loc, Loc);
 
   // Dst = (void*[n])(LHSArg);
@@ -5217,6 +5220,11 @@ void CGOpenMPRuntime::emitReduction(CodeGenFunction &CGF, SourceLocation Loc,
   llvm::Function *ReductionFn = emitReductionFunction(
       CGF.CurFn->getName(), Loc, CGF.ConvertTypeForMem(ReductionArrayTy),
       Privates, LHSExprs, RHSExprs, ReductionOps);
+  llvm::Value *ReductionFnP = ReductionFn;
+  if (CGF.SanOpts.has(SanitizerKind::Thread)) {
+    ReductionFnP = llvm::ConstantPointerNull::get(
+        llvm::PointerType::get(ReductionFn->getFunctionType(), 0));
+  }
 
   // 3. Create static kmp_critical_name lock = { 0 };
   std::string Name = getName({"reduction"});
@@ -5235,8 +5243,8 @@ void CGOpenMPRuntime::emitReduction(CodeGenFunction &CGF, SourceLocation Loc,
       CGF.Builder.getInt32(RHSExprs.size()), // i32 <n>
       ReductionArrayTySize,                  // size_type sizeof(RedList)
       RL,                                    // void *RedList
-      ReductionFn, // void (*) (void *, void *) <reduce_func>
-      Lock         // kmp_critical_name *&<lock>
+      ReductionFnP, // void (*) (void *, void *) <reduce_func>
+      Lock          // kmp_critical_name *&<lock>
   };
   llvm::Value *Res = CGF.EmitRuntimeCall(
       OMPBuilder.getOrCreateRuntimeFunction(

--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -89,6 +89,8 @@ check_cxx_compiler_flag(-fno-profile-instr-use COMPILER_RT_HAS_FNO_PROFILE_INSTR
 check_cxx_compiler_flag(-fno-coverage-mapping COMPILER_RT_HAS_FNO_COVERAGE_MAPPING_FLAG)
 check_cxx_compiler_flag("-Werror -mcrc32"    COMPILER_RT_HAS_MCRC32_FLAG)
 check_cxx_compiler_flag("-Werror -msse4.2"   COMPILER_RT_HAS_MSSE4_2_FLAG)
+check_cxx_compiler_flag("-Werror -mavx2"   COMPILER_RT_HAS_MAVX2_FLAG)
+check_cxx_compiler_flag("-Werror -mavx512f"   COMPILER_RT_HAS_MAVX512F_FLAG)
 check_cxx_compiler_flag(--sysroot=.          COMPILER_RT_HAS_SYSROOT_FLAG)
 check_cxx_compiler_flag("-Werror -mcrc"      COMPILER_RT_HAS_MCRC_FLAG)
 check_cxx_compiler_flag(-fno-partial-inlining COMPILER_RT_HAS_FNO_PARTIAL_INLINING_FLAG)

--- a/compiler-rt/lib/tsan/rtl/CMakeLists.txt
+++ b/compiler-rt/lib/tsan/rtl/CMakeLists.txt
@@ -237,6 +237,17 @@ else()
     else()
       set(TSAN_ASM_SOURCES)
     endif()
+    add_compiler_rt_object_libraries(RTTSanAVX2
+        ARCHS ${arch}
+        SOURCES tsan_interface_avx2.cpp
+        ADDITIONAL_HEADERS tsan_interface_avx2.h 
+        #CFLAGS ${TSAN_RTL_CFLAGS} $<IF:"$COMPILER_RT_HAS_MAVX2_FLAG","-mavx2","">)
+        CFLAGS ${TSAN_RTL_CFLAGS} $<IF:$<BOOL:${COMPILER_RT_HAS_MAVX2_FLAG}>,-mavx2,"">)
+    add_compiler_rt_object_libraries(RTTSanAVX512
+        ARCHS ${arch}
+        SOURCES tsan_interface_avx512.cpp
+        ADDITIONAL_HEADERS tsan_interface_avx512.h 
+        CFLAGS ${TSAN_RTL_CFLAGS} $<IF:$<BOOL:${COMPILER_RT_HAS_MAVX512F_FLAG}>,-mavx512f,"">)
     add_compiler_rt_runtime(clang_rt.tsan
       STATIC
       ARCHS ${arch}
@@ -247,6 +258,8 @@ else()
               $<TARGET_OBJECTS:RTSanitizerCommonCoverage.${arch}>
               $<TARGET_OBJECTS:RTSanitizerCommonSymbolizer.${arch}>
               $<TARGET_OBJECTS:RTUbsan.${arch}>
+              $<TARGET_OBJECTS:RTTSanAVX2.${arch}>
+              $<TARGET_OBJECTS:RTTSanAVX512.${arch}>
       ADDITIONAL_HEADERS ${TSAN_HEADERS}
       CFLAGS ${TSAN_RTL_CFLAGS}
       PARENT_TARGET tsan)
@@ -270,6 +283,8 @@ else()
               $<TARGET_OBJECTS:RTSanitizerCommonCoverage.${arch}>
               $<TARGET_OBJECTS:RTSanitizerCommonSymbolizer.${arch}>
               $<TARGET_OBJECTS:RTUbsan.${arch}>
+              $<TARGET_OBJECTS:RTTSanAVX2.${arch}>
+              $<TARGET_OBJECTS:RTTSanAVX512.${arch}>
       ADDITIONAL_HEADERS ${TSAN_HEADERS}
       CFLAGS ${TSAN_RTL_DYNAMIC_CFLAGS}
       DEFS SANITIZER_SHARED

--- a/compiler-rt/lib/tsan/rtl/tsan_interface.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface.cpp
@@ -13,6 +13,7 @@
 #include "tsan_interface.h"
 #include "tsan_interface_ann.h"
 #include "tsan_rtl.h"
+
 #include "sanitizer_common/sanitizer_internal_defs.h"
 #include "sanitizer_common/sanitizer_ptrauth.h"
 
@@ -42,18 +43,42 @@ void __tsan_write16_pc(void *addr, void *pc) {
 
 // __tsan_unaligned_read/write calls are emitted by compiler.
 
-void __tsan_unaligned_read16(const void *addr) {
+template <unsigned int N>
+void __tsan_unaligned_readx(const void *addr) {
   uptr pc = CALLERPC;
   ThreadState *thr = cur_thread();
-  UnalignedMemoryAccess(thr, pc, (uptr)addr, 8, kAccessRead);
-  UnalignedMemoryAccess(thr, pc, (uptr)addr + 8, 8, kAccessRead);
+  for (unsigned int i = 0; i < N / 8; i++)
+    UnalignedMemoryAccess(thr, pc, (uptr)addr + (i * 8), 8, kAccessRead);
 }
 
-void __tsan_unaligned_write16(void *addr) {
+template <unsigned int N>
+void __tsan_unaligned_writex(void *addr) {
   uptr pc = CALLERPC;
   ThreadState *thr = cur_thread();
-  UnalignedMemoryAccess(thr, pc, (uptr)addr, 8, kAccessWrite);
-  UnalignedMemoryAccess(thr, pc, (uptr)addr + 8, 8, kAccessWrite);
+  for (unsigned int i = 0; i < N / 8; i++)
+    UnalignedMemoryAccess(thr, pc, (uptr)addr + (i * 8), 8, kAccessWrite);
+}
+
+void __tsan_unaligned_read16(const void *addr) {
+  __tsan_unaligned_readx<16>(addr);
+}
+
+void __tsan_unaligned_write16(void *addr) { __tsan_unaligned_writex<16>(addr); }
+
+extern "C" void __tsan_unaligned_read32(const void *addr) {
+  __tsan_unaligned_readx<32>(addr);
+}
+
+extern "C" void __tsan_unaligned_write32(void *addr) {
+  __tsan_unaligned_writex<32>(addr);
+}
+
+extern "C" void __tsan_unaligned_read64(const void *addr) {
+  __tsan_unaligned_readx<64>(addr);
+}
+
+extern "C" void __tsan_unaligned_write64(void *addr) {
+  __tsan_unaligned_writex<64>(addr);
 }
 
 extern "C" {

--- a/compiler-rt/lib/tsan/rtl/tsan_interface.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface.h
@@ -53,11 +53,15 @@ SANITIZER_INTERFACE_ATTRIBUTE void __tsan_unaligned_read2(const void *addr);
 SANITIZER_INTERFACE_ATTRIBUTE void __tsan_unaligned_read4(const void *addr);
 SANITIZER_INTERFACE_ATTRIBUTE void __tsan_unaligned_read8(const void *addr);
 SANITIZER_INTERFACE_ATTRIBUTE void __tsan_unaligned_read16(const void *addr);
+SANITIZER_INTERFACE_ATTRIBUTE void __tsan_unaligned_read32(const void *addr);
+SANITIZER_INTERFACE_ATTRIBUTE void __tsan_unaligned_read64(const void *addr);
 
 SANITIZER_INTERFACE_ATTRIBUTE void __tsan_unaligned_write2(void *addr);
 SANITIZER_INTERFACE_ATTRIBUTE void __tsan_unaligned_write4(void *addr);
 SANITIZER_INTERFACE_ATTRIBUTE void __tsan_unaligned_write8(void *addr);
 SANITIZER_INTERFACE_ATTRIBUTE void __tsan_unaligned_write16(void *addr);
+SANITIZER_INTERFACE_ATTRIBUTE void __tsan_unaligned_write32(void *addr);
+SANITIZER_INTERFACE_ATTRIBUTE void __tsan_unaligned_write64(void *addr);
 
 SANITIZER_INTERFACE_ATTRIBUTE void __tsan_read1_pc(void *addr, void *pc);
 SANITIZER_INTERFACE_ATTRIBUTE void __tsan_read2_pc(void *addr, void *pc);

--- a/compiler-rt/lib/tsan/rtl/tsan_interface.inc
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface.inc
@@ -38,6 +38,18 @@ void __tsan_read16(void *addr) {
   MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr, kAccessRead);
 }
 
+extern "C" void __tsan_read32(void *addr) {
+  MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr, kAccessRead);
+  MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr + 16, kAccessRead);
+}
+
+extern "C" void __tsan_read64(void *addr) {
+  MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr, kAccessRead);
+  MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr + 16, kAccessRead);
+  MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr + 32, kAccessRead);
+  MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr + 48, kAccessRead);
+}
+
 void __tsan_write1(void *addr) {
   MemoryAccess(cur_thread(), CALLERPC, (uptr)addr, 1, kAccessWrite);
 }
@@ -57,6 +69,21 @@ void __tsan_write8(void *addr) {
 void __tsan_write16(void *addr) {
   MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr, kAccessWrite);
 }
+
+extern "C" void __tsan_write32(void *addr) {
+  MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr, kAccessWrite);
+  MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr + 16, kAccessWrite);
+}
+
+extern "C" void __tsan_write64(void *addr) {
+  MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr, kAccessWrite);
+  MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr + 16, kAccessWrite);
+  MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr + 32, kAccessWrite);
+  MemoryAccess16(cur_thread(), CALLERPC, (uptr)addr + 48, kAccessWrite);
+}
+
+// Our vector instructions
+// TODO
 
 void __tsan_read1_pc(void *addr, void *pc) {
   MemoryAccess(cur_thread(), STRIP_PAC_PC(pc), (uptr)addr, 1, kAccessRead | kAccessExternalPC);

--- a/compiler-rt/lib/tsan/rtl/tsan_interface_ann.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface_ann.cpp
@@ -266,6 +266,16 @@ void INTERFACE_ATTRIBUTE AnnotateBenignRace(
   BenignRaceImpl(f, l, mem, 1, desc);
 }
 
+void INTERFACE_ATTRIBUTE AnnotateAllAtomicBegin(char *f, int l) {
+  SCOPED_ANNOTATION(AnnotateAllAtomicBegin);
+  ThreadAtomicBegin(thr, pc);
+}
+
+void INTERFACE_ATTRIBUTE AnnotateAllAtomicEnd(char *f, int l) {
+  SCOPED_ANNOTATION(AnnotateAllAtomicEnd);
+  ThreadAtomicEnd(thr);
+}
+
 void INTERFACE_ATTRIBUTE AnnotateIgnoreReadsBegin(char *f, int l) {
   SCOPED_ANNOTATION(AnnotateIgnoreReadsBegin);
   ThreadIgnoreBegin(thr, pc);

--- a/compiler-rt/lib/tsan/rtl/tsan_interface_avx2.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface_avx2.cpp
@@ -1,0 +1,37 @@
+#include "tsan_interface_avx2.h"
+
+#include <immintrin.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "sanitizer_common/sanitizer_internal_defs.h"
+#include "sanitizer_common/sanitizer_ptrauth.h"
+#include "tsan_interface_ann.h"
+#include "tsan_rtl.h"
+
+#define CALLERPC ((uptr)__builtin_return_address(0))
+
+using namespace __tsan;
+
+#ifdef __AVX__
+extern "C" void __tsan_scatter_vector4(__m256i vaddr, int size, uint8_t mask) {
+  void *addr[4] = {};
+  _mm256_store_si256((__m256i *)addr, vaddr);
+  uptr pc = CALLERPC;
+  ThreadState *thr = cur_thread();
+  for (int i = 0; i < 4; i++)
+    if ((mask >> i) & 1)
+      UnalignedMemoryAccess(thr, pc, (uptr)addr[i], size, kAccessWrite);
+}
+
+extern "C" void __tsan_gather_vector4(__m256i vaddr, int size, uint8_t mask) {
+  void *addr[4] = {};
+  _mm256_store_si256((__m256i *)addr, vaddr);
+  uptr pc = CALLERPC;
+  ThreadState *thr = cur_thread();
+  for (int i = 0; i < 4; i++)
+    if ((mask >> i) & 1)
+      UnalignedMemoryAccess(thr, pc, (uptr)addr[i], size, kAccessRead);
+}
+#endif /*__AVX__*/

--- a/compiler-rt/lib/tsan/rtl/tsan_interface_avx2.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface_avx2.h
@@ -1,0 +1,46 @@
+//===-- tsan_interface_avx2.h ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of ThreadSanitizer (TSan), a race detector.
+//
+// The functions declared in this header will be inserted by the instrumentation
+// module.
+// This header can be included by the instrumented program or by TSan tests.
+//===----------------------------------------------------------------------===//
+#ifndef TSAN_INTERFACE_AVX2_H
+#define TSAN_INTERFACE_AVX2_H
+
+#include <immintrin.h>
+#include <sanitizer_common/sanitizer_internal_defs.h>
+#include <stdint.h>
+using __sanitizer::tid_t;
+using __sanitizer::uptr;
+
+// This header should NOT include any other headers.
+// All functions in this header are extern "C" and start with __tsan_.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !SANITIZER_GO
+#  ifdef __AVX__
+SANITIZER_INTERFACE_ATTRIBUTE void __tsan_scatter_vector4(__m256i vaddr,
+                                                          int width,
+                                                          uint8_t mask);
+SANITIZER_INTERFACE_ATTRIBUTE void __tsan_gather_vector4(__m256i vaddr,
+                                                         int width,
+                                                         uint8_t mask);
+#  endif /*__AVX__*/
+#endif   // SANITIZER_GO
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif /*TSAN_INTERFACE_AVX2_H*/

--- a/compiler-rt/lib/tsan/rtl/tsan_interface_avx512.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface_avx512.cpp
@@ -1,0 +1,43 @@
+#include "tsan_interface_avx512.h"
+
+#include <immintrin.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "sanitizer_common/sanitizer_internal_defs.h"
+#include "sanitizer_common/sanitizer_ptrauth.h"
+#include "tsan_interface_ann.h"
+#include "tsan_rtl.h"
+
+#define CALLERPC ((uptr)__builtin_return_address(0))
+
+using namespace __tsan;
+
+#ifdef __AVX512F__
+extern "C" void __tsan_scatter_vector8(__m512i vaddr, int size, uint8_t mask) {
+  void *addr[8] = {};
+  __m256i v256_1 = _mm512_extracti64x4_epi64(vaddr, 0);
+  __m256i v256_2 = _mm512_extracti64x4_epi64(vaddr, 4);
+  _mm256_store_si256((__m256i *)addr, v256_1);
+  _mm256_store_si256((__m256i *)&(addr[4]), v256_2);
+  uptr pc = CALLERPC;
+  ThreadState *thr = cur_thread();
+  for (int i = 0; i < 8; i++)
+    if ((mask >> i) & 1)
+      UnalignedMemoryAccess(thr, pc, (uptr)addr[i], size, kAccessWrite);
+}
+
+extern "C" void __tsan_gather_vector8(__m512i vaddr, int size, uint8_t mask) {
+  void *addr[8] = {};
+  __m256i v256_1 = _mm512_extracti64x4_epi64(vaddr, 0);
+  __m256i v256_2 = _mm512_extracti64x4_epi64(vaddr, 4);
+  _mm256_store_si256((__m256i *)addr, v256_1);
+  _mm256_store_si256((__m256i *)(&addr[4]), v256_2);
+  uptr pc = CALLERPC;
+  ThreadState *thr = cur_thread();
+  for (int i = 0; i < 8; i++)
+    if ((mask >> i) & 1)
+      UnalignedMemoryAccess(thr, pc, (uptr)addr[i], size, kAccessRead);
+}
+#endif /*__AVX512F__*/

--- a/compiler-rt/lib/tsan/rtl/tsan_interface_avx512.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_interface_avx512.h
@@ -1,0 +1,46 @@
+//===-- tsan_interface_avx512.h ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of ThreadSanitizer (TSan), a race detector.
+//
+// The functions declared in this header will be inserted by the instrumentation
+// module.
+// This header can be included by the instrumented program or by TSan tests.
+//===----------------------------------------------------------------------===//
+#ifndef TSAN_INTERFACE_AVX512_H
+#define TSAN_INTERFACE_AVX512_H
+
+#include <immintrin.h>
+#include <sanitizer_common/sanitizer_internal_defs.h>
+#include <stdint.h>
+using __sanitizer::tid_t;
+using __sanitizer::uptr;
+
+// This header should NOT include any other headers.
+// All functions in this header are extern "C" and start with __tsan_.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !SANITIZER_GO
+#  ifdef __AVX512F__
+SANITIZER_INTERFACE_ATTRIBUTE void __tsan_scatter_vector8(__m512i vaddr,
+                                                          int width,
+                                                          uint8_t mask);
+SANITIZER_INTERFACE_ATTRIBUTE void __tsan_gather_vector8(__m512i vaddr,
+                                                         int width,
+                                                         uint8_t mask);
+#  endif /*__AVX512F__*/
+#endif   // SANITIZER_GO
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif /*TSAN_INTERFACE_AVX512_H*/

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl.cpp
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl.cpp
@@ -1053,6 +1053,21 @@ void ThreadIgnoreEnd(ThreadState *thr) {
   }
 }
 
+void ThreadAtomicBegin(ThreadState* thr, uptr pc) {
+  thr->all_atomic++;
+//  CHECK_GT(thr->ignore_reads_and_writes, 0);
+  CHECK_EQ(thr->all_atomic, 1);
+  thr->fast_state.SetAtomicBit();
+}
+
+void ThreadAtomicEnd(ThreadState *thr) {
+  CHECK_GT(thr->all_atomic, 0);
+  thr->all_atomic--;
+  if (thr->all_atomic == 0) {
+    thr->fast_state.ClearAtomicBit();
+  }
+}
+
 #if !SANITIZER_GO
 extern "C" SANITIZER_INTERFACE_ATTRIBUTE
 uptr __tsan_testonly_shadow_stack_current_size() {

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl.h
@@ -182,6 +182,7 @@ struct ThreadState {
   // for better performance.
   int ignore_reads_and_writes;
   int suppress_reports;
+  int all_atomic;
   // Go does not support ignores.
 #if !SANITIZER_GO
   IgnoreSet mop_ignore_set;
@@ -550,6 +551,8 @@ void MemoryRangeImitateWrite(ThreadState *thr, uptr pc, uptr addr, uptr size);
 void MemoryRangeImitateWriteOrResetRange(ThreadState *thr, uptr pc, uptr addr,
                                          uptr size);
 
+void ThreadAtomicBegin(ThreadState *thr, uptr pc);
+void ThreadAtomicEnd(ThreadState *thr);
 void ThreadIgnoreBegin(ThreadState *thr, uptr pc);
 void ThreadIgnoreEnd(ThreadState *thr);
 void ThreadIgnoreSyncBegin(ThreadState *thr, uptr pc);

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl.h
@@ -801,6 +801,7 @@ void FuncExit(ThreadState *thr) {
 #if !SANITIZER_GO
   DCHECK_LT(thr->shadow_stack_pos, thr->shadow_stack_end);
 #endif
+  CHECK_GT(thr->shadow_stack_pos, thr->shadow_stack);
   thr->shadow_stack_pos--;
 }
 

--- a/compiler-rt/lib/tsan/rtl/tsan_rtl.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_rtl.h
@@ -56,8 +56,8 @@ namespace __tsan {
 
 #if !SANITIZER_GO
 struct MapUnmapCallback;
-#if defined(__mips64) || defined(__aarch64__) || defined(__loongarch__) || \
-    defined(__powerpc__)
+#  if defined(__mips64) || defined(__aarch64__) || defined(__loongarch__) || \
+      defined(__powerpc__)
 
 struct AP32 {
   static const uptr kSpaceBeg = 0;

--- a/compiler-rt/lib/tsan/rtl/tsan_shadow.h
+++ b/compiler-rt/lib/tsan/rtl/tsan_shadow.h
@@ -9,6 +9,7 @@
 #ifndef TSAN_SHADOW_H
 #define TSAN_SHADOW_H
 
+#include "sanitizer_common/sanitizer_common.h"
 #include "tsan_defs.h"
 
 namespace __tsan {
@@ -21,8 +22,8 @@ class FastState {
     part_.unused0_ = 0;
     part_.sid_ = static_cast<u8>(kFreeSid);
     part_.epoch_ = static_cast<u16>(kEpochLast);
-    part_.unused1_ = 0;
     part_.ignore_accesses_ = false;
+    part_.all_atomic_ = false;
   }
 
   void SetSid(Sid sid) { part_.sid_ = static_cast<u8>(sid); }
@@ -37,14 +38,18 @@ class FastState {
   void ClearIgnoreBit() { part_.ignore_accesses_ = 0; }
   bool GetIgnoreBit() const { return part_.ignore_accesses_; }
 
+  void SetAtomicBit() { part_.all_atomic_ = 1; }
+  void ClearAtomicBit() { part_.all_atomic_ = 0; }
+  bool GetAtomicBit() const { return part_.all_atomic_; }
+
  private:
   friend class Shadow;
   struct Parts {
     u32 unused0_ : 8;
     u32 sid_ : 8;
     u32 epoch_ : kEpochBits;
-    u32 unused1_ : 1;
     u32 ignore_accesses_ : 1;
+    u32 all_atomic_ : 1;
   };
   union {
     Parts part_;

--- a/compiler-rt/test/tsan/simd_broadcast_norace.c
+++ b/compiler-rt/test/tsan/simd_broadcast_norace.c
@@ -1,0 +1,45 @@
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %run %t 2>&1 | FileCheck %s
+#include "test.h"
+
+#ifndef SIMDLEN
+#  define SIMDLEN 8
+#endif /*SIMDLEN*/
+#ifndef TYPE
+#  define TYPE double
+#endif /*TYPE*/
+#define LEN 256
+#define CHUNK_SIZE 64
+
+TYPE A[2 * LEN];
+TYPE c;
+
+void *Thread(intptr_t offset) {
+  for (intptr_t i = offset; i < LEN; i += (2 * CHUNK_SIZE)) {
+#pragma omp simd simdlen(SIMDLEN)
+    for (intptr_t j = i; j < i + CHUNK_SIZE; j++)
+      A[j] += c;
+  }
+  barrier_wait(&barrier);
+  return NULL;
+}
+
+void *Thread1(void *x) { return Thread(0); }
+
+void *Thread2(void *x) { return Thread(CHUNK_SIZE); }
+
+int main() {
+  barrier_init(&barrier, 2);
+  pthread_t t[2];
+  pthread_create(&t[0], NULL, Thread1, NULL);
+  pthread_create(&t[1], NULL, Thread2, NULL);
+  pthread_join(t[0], NULL);
+  pthread_join(t[1], NULL);
+  fprintf(stderr, "DONE\n");
+  return 0;
+}
+
+// CHECK-NOT: WARNING: ThreadSanitizer: data race
+// CHECK-NOT: SUMMARY: ThreadSanitizer: data race{{.*}}Thread

--- a/compiler-rt/test/tsan/simd_broadcast_race.c
+++ b/compiler-rt/test/tsan/simd_broadcast_race.c
@@ -1,0 +1,43 @@
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+#include "test.h"
+
+#ifndef SIMDLEN
+#  define SIMDLEN 8
+#endif /*SIMDLEN*/
+#ifndef TYPE
+#  define TYPE double
+#endif /*TYPE*/
+#define LEN 256
+#define CHUNK_SIZE 64
+
+TYPE A[2 * LEN];
+
+void *Thread(intptr_t offset) {
+  for (intptr_t i = offset; i < LEN; i += (2 * CHUNK_SIZE)) {
+#pragma omp simd simdlen(SIMDLEN)
+    for (intptr_t j = i; j < i + CHUNK_SIZE; j++)
+      A[j] += A[64];
+  }
+  barrier_wait(&barrier);
+  return NULL;
+}
+
+void *Thread1(void *x) { return Thread(0); }
+
+void *Thread2(void *x) { return Thread(CHUNK_SIZE); }
+
+int main() {
+  barrier_init(&barrier, 2);
+  pthread_t t[2];
+  pthread_create(&t[0], NULL, Thread1, NULL);
+  pthread_create(&t[1], NULL, Thread2, NULL);
+  pthread_join(t[0], NULL);
+  pthread_join(t[1], NULL);
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: SUMMARY: ThreadSanitizer: data race{{.*}}Thread

--- a/compiler-rt/test/tsan/simd_gather_race.c
+++ b/compiler-rt/test/tsan/simd_gather_race.c
@@ -1,0 +1,44 @@
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+#include "test.h"
+
+#ifndef SIMDLEN
+#  define SIMDLEN 8
+#endif /*SIMDLEN*/
+#ifndef TYPE
+#  define TYPE double
+#endif /*TYPE*/
+#define LEN 256
+#define CHUNK_SIZE 64
+
+TYPE A[2 * LEN];
+TYPE B[LEN];
+
+void *Thread(intptr_t offset) {
+  for (intptr_t i = offset; i < LEN; i += (2 * CHUNK_SIZE)) {
+#pragma omp simd simdlen(SIMDLEN)
+    for (intptr_t j = i; j < i + CHUNK_SIZE; j++)
+      A[j + CHUNK_SIZE] = A[j * 2] + B[j];
+  }
+  barrier_wait(&barrier);
+  return NULL;
+}
+
+void *Thread1(void *x) { return Thread(0); }
+
+void *Thread2(void *x) { return Thread(CHUNK_SIZE); }
+
+int main() {
+  barrier_init(&barrier, 2);
+  pthread_t t[2];
+  pthread_create(&t[0], NULL, Thread1, NULL);
+  pthread_create(&t[1], NULL, Thread2, NULL);
+  pthread_join(t[0], NULL);
+  pthread_join(t[1], NULL);
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: SUMMARY: ThreadSanitizer: data race{{.*}}Thread

--- a/compiler-rt/test/tsan/simd_gatherscatter_norace.c
+++ b/compiler-rt/test/tsan/simd_gatherscatter_norace.c
@@ -1,0 +1,45 @@
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %run %t 2>&1 | FileCheck %s
+#include "test.h"
+
+#ifndef SIMDLEN
+#  define SIMDLEN 8
+#endif /*SIMDLEN*/
+#ifndef TYPE
+#  define TYPE double
+#endif /*TYPE*/
+#define LEN 256
+#define CHUNK_SIZE 64
+
+TYPE A[2 * LEN];
+TYPE B[LEN];
+
+void *Thread(intptr_t offset) {
+  for (intptr_t i = offset; i < LEN; i += (2 * CHUNK_SIZE)) {
+#pragma omp simd simdlen(SIMDLEN)
+    for (intptr_t j = i; j < i + CHUNK_SIZE; j++)
+      A[j * 2] += B[j];
+  }
+  barrier_wait(&barrier);
+  return NULL;
+}
+
+void *Thread1(void *x) { return Thread(0); }
+
+void *Thread2(void *x) { return Thread(CHUNK_SIZE); }
+
+int main() {
+  barrier_init(&barrier, 2);
+  pthread_t t[2];
+  pthread_create(&t[0], NULL, Thread1, NULL);
+  pthread_create(&t[1], NULL, Thread2, NULL);
+  pthread_join(t[0], NULL);
+  pthread_join(t[1], NULL);
+  fprintf(stderr, "DONE\n");
+  return 0;
+}
+
+// CHECK-NOT: WARNING: ThreadSanitizer: data race
+// CHECK-NOT: SUMMARY: ThreadSanitizer: data race{{.*}}Thread

--- a/compiler-rt/test/tsan/simd_loadstore_norace.c
+++ b/compiler-rt/test/tsan/simd_loadstore_norace.c
@@ -1,0 +1,45 @@
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %run %t 2>&1 | FileCheck %s
+#include "test.h"
+
+#ifndef SIMDLEN
+#  define SIMDLEN 8
+#endif /*SIMDLEN*/
+#ifndef TYPE
+#  define TYPE double
+#endif /*TYPE*/
+#define LEN 256
+#define CHUNK_SIZE 64
+
+TYPE A[2 * LEN];
+TYPE B[LEN];
+
+void *Thread(intptr_t offset) {
+  for (intptr_t i = offset; i < LEN; i += (2 * CHUNK_SIZE)) {
+#pragma omp simd simdlen(SIMDLEN)
+    for (intptr_t j = i; j < i + CHUNK_SIZE; j++)
+      A[j] += B[j];
+  }
+  barrier_wait(&barrier);
+  return NULL;
+}
+
+void *Thread1(void *x) { return Thread(0); }
+
+void *Thread2(void *x) { return Thread(CHUNK_SIZE); }
+
+int main() {
+  barrier_init(&barrier, 2);
+  pthread_t t[2];
+  pthread_create(&t[0], NULL, Thread1, NULL);
+  pthread_create(&t[1], NULL, Thread2, NULL);
+  pthread_join(t[0], NULL);
+  pthread_join(t[1], NULL);
+  fprintf(stderr, "DONE\n");
+  return 0;
+}
+
+// CHECK-NOT: WARNING: ThreadSanitizer: data race
+// CHECK-NOT: SUMMARY: ThreadSanitizer: data race{{.*}}Thread

--- a/compiler-rt/test/tsan/simd_loadstore_race.c
+++ b/compiler-rt/test/tsan/simd_loadstore_race.c
@@ -1,0 +1,44 @@
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+#include "test.h"
+
+#ifndef SIMDLEN
+#  define SIMDLEN 8
+#endif /*SIMDLEN*/
+#ifndef TYPE
+#  define TYPE double
+#endif /*TYPE*/
+#define LEN 256
+#define CHUNK_SIZE 64
+
+TYPE A[2 * LEN];
+TYPE B[LEN];
+
+void *Thread(intptr_t offset) {
+  for (intptr_t i = offset; i < LEN; i += (2 * CHUNK_SIZE)) {
+#pragma omp simd simdlen(SIMDLEN)
+    for (intptr_t j = i; j < i + CHUNK_SIZE; j++)
+      A[j + 64] = A[j] + B[j];
+  }
+  barrier_wait(&barrier);
+  return NULL;
+}
+
+void *Thread1(void *x) { return Thread(0); }
+
+void *Thread2(void *x) { return Thread(CHUNK_SIZE); }
+
+int main() {
+  barrier_init(&barrier, 2);
+  pthread_t t[2];
+  pthread_create(&t[0], NULL, Thread1, NULL);
+  pthread_create(&t[1], NULL, Thread2, NULL);
+  pthread_join(t[0], NULL);
+  pthread_join(t[1], NULL);
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: SUMMARY: ThreadSanitizer: data race{{.*}}Thread

--- a/compiler-rt/test/tsan/simd_scatter_mask_norace.c
+++ b/compiler-rt/test/tsan/simd_scatter_mask_norace.c
@@ -1,0 +1,56 @@
+// RUN: %clang_tsan -march=native -DSIMDLEN=4 -DTYPE=float %s -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -march=native -DSIMDLEN=4 -DTYPE=double %s -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -march=native -DSIMDLEN=8 -DTYPE=float %s -o %t && %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -march=native -DSIMDLEN=8 -DTYPE=double %s -o %t && %run %t 2>&1 | FileCheck %s
+#include "test.h"
+#include <immintrin.h>
+#include <stdint.h>
+
+#ifndef SIMDLEN
+#  define SIMDLEN 8
+#endif /*SIMDLEN*/
+#ifndef TYPE
+#  define TYPE double
+#endif /*TYPE*/
+
+#if SIMDLEN == 4
+#  define tsan_scatter_func __tsan_scatter_vector4
+#  define intri_type __m256i
+#elif SIMDLEN == 8
+#  define tsan_scatter_func __tsan_scatter_vector8
+#  define intri_type __m512i
+#endif
+
+extern void tsan_scatter_func(intri_type, int, uint8_t);
+TYPE A[8];
+
+__attribute__((disable_sanitizer_instrumentation)) void *Thread(uint8_t mask) {
+#if SIMDLEN == 4
+  __m256i vaddr = _mm256_set_epi64x(
+#elif SIMDLEN == 8
+  __m512i vaddr = _mm512_set_epi64(
+      (int64_t)(A + 7), (int64_t)(A + 6), (int64_t)(A + 5), (int64_t)(A + 4),
+#endif
+      (int64_t)(A + 3), (int64_t)(A + 2), (int64_t)(A + 1), (int64_t)(A + 0));
+  tsan_scatter_func(vaddr, sizeof(TYPE), mask);
+  barrier_wait(&barrier);
+  return NULL;
+}
+
+void *Thread1(void *x) { return Thread(0b01010101); }
+
+void *Thread2(void *x) { return Thread(0b10101010); }
+
+int main() {
+  barrier_init(&barrier, 2);
+  pthread_t t[2];
+  pthread_create(&t[0], NULL, Thread1, NULL);
+  pthread_create(&t[1], NULL, Thread2, NULL);
+  pthread_join(t[0], NULL);
+  pthread_join(t[1], NULL);
+  fprintf(stderr, "DONE.\n");
+  return 0;
+}
+
+// CHECK-NOT: WARNING: ThreadSanitizer: data race
+// CHECK-NOT: SUMMARY: ThreadSanitizer: data race{{.*}}Thread

--- a/compiler-rt/test/tsan/simd_scatter_mask_race.c
+++ b/compiler-rt/test/tsan/simd_scatter_mask_race.c
@@ -1,0 +1,55 @@
+// RUN: %clang_tsan -march=native -DSIMDLEN=4 -DTYPE=float %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -march=native -DSIMDLEN=4 -DTYPE=double %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -march=native -DSIMDLEN=8 -DTYPE=float %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -march=native -DSIMDLEN=8 -DTYPE=double %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+#include "test.h"
+#include <immintrin.h>
+#include <stdint.h>
+
+#ifndef SIMDLEN
+#  define SIMDLEN 8
+#endif /*SIMDLEN*/
+#ifndef TYPE
+#  define TYPE double
+#endif /*TYPE*/
+
+#if SIMDLEN == 4
+#  define tsan_scatter_func __tsan_scatter_vector4
+#  define intri_type __m256i
+#elif SIMDLEN == 8
+#  define tsan_scatter_func __tsan_scatter_vector8
+#  define intri_type __m512i
+#endif
+
+extern void tsan_scatter_func(intri_type, int, uint8_t);
+TYPE A[8];
+
+__attribute__((disable_sanitizer_instrumentation)) void *Thread(uint8_t mask) {
+#if SIMDLEN == 4
+  __m256i vaddr = _mm256_set_epi64x(
+#elif SIMDLEN == 8
+  __m512i vaddr = _mm512_set_epi64(
+      (int64_t)(A + 7), (int64_t)(A + 6), (int64_t)(A + 5), (int64_t)(A + 4),
+#endif
+      (int64_t)(A + 3), (int64_t)(A + 2), (int64_t)(A + 1), (int64_t)(A + 0));
+  tsan_scatter_func(vaddr, sizeof(TYPE), mask);
+  barrier_wait(&barrier);
+  return NULL;
+}
+
+void *Thread1(void *x) { return Thread(0b01010101); }
+
+void *Thread2(void *x) { return Thread(0b10101011); }
+
+int main() {
+  barrier_init(&barrier, 2);
+  pthread_t t[2];
+  pthread_create(&t[0], NULL, Thread1, NULL);
+  pthread_create(&t[1], NULL, Thread2, NULL);
+  pthread_join(t[0], NULL);
+  pthread_join(t[1], NULL);
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: SUMMARY: ThreadSanitizer: data race{{.*}}Thread

--- a/compiler-rt/test/tsan/simd_scatter_race.c
+++ b/compiler-rt/test/tsan/simd_scatter_race.c
@@ -1,0 +1,44 @@
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=4 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=float -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+// RUN: %clang_tsan -DSIMDLEN=8 -DTYPE=double -O3 -march=native -fopenmp-simd %s -o %t && %deflake %run %t 2>&1 | FileCheck %s
+#include "test.h"
+
+#ifndef SIMDLEN
+#  define SIMDLEN 8
+#endif /*SIMDLEN*/
+#ifndef TYPE
+#  define TYPE double
+#endif /*TYPE*/
+#define LEN 2000
+#define CHUNK_SIZE 64
+
+TYPE A[2 * LEN];
+TYPE B[LEN];
+
+void *Thread(intptr_t offset) {
+  for (intptr_t i = offset; i < LEN; i += (2 * CHUNK_SIZE)) {
+#pragma omp simd simdlen(SIMDLEN)
+    for (intptr_t j = i; j < i + CHUNK_SIZE; j++)
+      A[j * 2] = A[j + CHUNK_SIZE] + B[j];
+  }
+  barrier_wait(&barrier);
+  return NULL;
+}
+
+void *Thread1(void *x) { return Thread(0); }
+
+void *Thread2(void *x) { return Thread(CHUNK_SIZE); }
+
+int main() {
+  barrier_init(&barrier, 2);
+  pthread_t t[2];
+  pthread_create(&t[0], NULL, Thread1, NULL);
+  pthread_create(&t[1], NULL, Thread2, NULL);
+  pthread_join(t[0], NULL);
+  pthread_join(t[1], NULL);
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: SUMMARY: ThreadSanitizer: data race{{.*}}Thread

--- a/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
@@ -67,6 +67,9 @@ static cl::opt<bool> ClInstrumentAtomics("tsan-instrument-atomics",
                                          cl::init(true),
                                          cl::desc("Instrument atomics"),
                                          cl::Hidden);
+static cl::opt<bool> ClInstrumentSimd("tsan-instrument-simd", cl::init(true),
+                                      cl::desc("Instrument simd instructions"),
+                                      cl::Hidden);
 static cl::opt<bool> ClInstrumentMemIntrinsics(
     "tsan-instrument-memintrinsics", cl::init(true),
     cl::desc("Instrument memintrinsics (memset/memcpy/memmove)"), cl::Hidden);
@@ -142,6 +145,7 @@ private:
   bool addrPointsToConstantData(Value *Addr);
   int getMemoryAccessFuncIndex(Type *OrigTy, Value *Addr, const DataLayout &DL);
   void InsertRuntimeIgnores(Function &F);
+  bool instrumentGatherOrScatter(Instruction *I, const DataLayout &DL);
 
   Type *IntptrTy;
   FunctionCallee TsanFuncEntry;
@@ -149,7 +153,7 @@ private:
   FunctionCallee TsanIgnoreBegin;
   FunctionCallee TsanIgnoreEnd;
   // Accesses sizes are powers of two: 1, 2, 4, 8, 16.
-  static const size_t kNumberOfAccessSizes = 5;
+  static const size_t kNumberOfAccessSizes = 9;
   FunctionCallee TsanRead[kNumberOfAccessSizes];
   FunctionCallee TsanWrite[kNumberOfAccessSizes];
   FunctionCallee TsanUnalignedRead[kNumberOfAccessSizes];
@@ -170,6 +174,8 @@ private:
   FunctionCallee TsanVptrUpdate;
   FunctionCallee TsanVptrLoad;
   FunctionCallee MemmoveFn, MemcpyFn, MemsetFn;
+  FunctionCallee TsanVectorScatter[2];
+  FunctionCallee TsanVectorGather[2];
 };
 
 void insertModuleCtor(Module &M) {
@@ -213,6 +219,24 @@ void ThreadSanitizer::initialize(Module &M, const TargetLibraryInfo &TLI) {
   TsanIgnoreEnd =
       M.getOrInsertFunction("__tsan_ignore_thread_end", Attr, IRB.getVoidTy());
   IntegerType *OrdTy = IRB.getInt32Ty();
+
+  TsanVectorScatter[0] = M.getOrInsertFunction(
+      SmallString<32>("__tsan_scatter_vector4"), Attr, IRB.getVoidTy(),
+      VectorType::get(IRB.getInt8PtrTy(), ElementCount::getFixed(4)),
+      IRB.getInt32Ty(), IRB.getInt8Ty());
+  TsanVectorScatter[1] = M.getOrInsertFunction(
+      SmallString<32>("__tsan_scatter_vector8"), Attr, IRB.getVoidTy(),
+      VectorType::get(IRB.getInt8PtrTy(), ElementCount::getFixed(8)),
+      IRB.getInt32Ty(), IRB.getInt8Ty());
+  TsanVectorGather[0] = M.getOrInsertFunction(
+      SmallString<32>("__tsan_gather_vector4"), Attr, IRB.getVoidTy(),
+      VectorType::get(IRB.getInt8PtrTy(), ElementCount::getFixed(4)),
+      IRB.getInt32Ty(), IRB.getInt8Ty());
+  TsanVectorGather[1] = M.getOrInsertFunction(
+      SmallString<32>("__tsan_gather_vector8"), Attr, IRB.getVoidTy(),
+      VectorType::get(IRB.getInt8PtrTy(), ElementCount::getFixed(8)),
+      IRB.getInt32Ty(), IRB.getInt8Ty());
+
   for (size_t i = 0; i < kNumberOfAccessSizes; ++i) {
     const unsigned ByteSize = 1U << i;
     const unsigned BitSize = ByteSize * 8;
@@ -511,27 +535,37 @@ bool ThreadSanitizer::sanitizeFunction(Function &F,
 
   initialize(*F.getParent(), TLI);
   SmallVector<InstructionInfo, 8> AllLoadsAndStores;
-  SmallVector<Instruction*, 8> LocalLoadsAndStores;
-  SmallVector<Instruction*, 8> AtomicAccesses;
-  SmallVector<Instruction*, 8> MemIntrinCalls;
+  SmallVector<Instruction *, 8> LocalLoadsAndStores;
+  SmallVector<Instruction *, 8> AtomicAccesses;
+  SmallVector<Instruction *, 8> MemIntrinCalls;
+  SmallVector<Instruction *, 8> AllGathersAndScatters;
+
   bool Res = false;
   bool HasCalls = false;
   bool SanitizeFunction = F.hasFnAttribute(Attribute::SanitizeThread);
   const DataLayout &DL = F.getParent()->getDataLayout();
 
-  // Traverse all instructions, collect loads/stores/returns, check for calls.
+  // Traverse all instructions, collect loads/stores/returns/gathers/scatters,
+  // check for calls.
   for (auto &BB : F) {
     for (auto &Inst : BB) {
-      if (isTsanAtomic(&Inst))
+      if (isTsanAtomic(&Inst)) {
         AtomicAccesses.push_back(&Inst);
-      else if (isa<LoadInst>(Inst) || isa<StoreInst>(Inst))
+      } else if (isa<LoadInst>(Inst) || isa<StoreInst>(Inst)) {
         LocalLoadsAndStores.push_back(&Inst);
-      else if ((isa<CallInst>(Inst) && !isa<DbgInfoIntrinsic>(Inst)) ||
-               isa<InvokeInst>(Inst)) {
-        if (CallInst *CI = dyn_cast<CallInst>(&Inst))
+      } else if ((isa<CallInst>(Inst) && !isa<DbgInfoIntrinsic>(Inst)) ||
+                 isa<InvokeInst>(Inst)) {
+        if (CallInst *CI = dyn_cast<CallInst>(&Inst)) {
+          auto CFunc = CI->getCalledFunction();
+          if (CFunc && (CFunc->getName().contains("llvm.masked.scatter") ||
+                        CFunc->getName().contains("llvm.masked.gather"))) {
+            AllGathersAndScatters.push_back(&Inst);
+          }
           maybeMarkSanitizerLibraryCallNoBuiltin(CI, &TLI);
-        if (isa<MemIntrinsic>(Inst))
+        }
+        if (isa<MemIntrinsic>(Inst)) {
           MemIntrinCalls.push_back(&Inst);
+        }
         HasCalls = true;
         chooseInstructionsToInstrument(LocalLoadsAndStores, AllLoadsAndStores,
                                        DL);
@@ -548,6 +582,12 @@ bool ThreadSanitizer::sanitizeFunction(Function &F,
   if (ClInstrumentMemoryAccesses && SanitizeFunction)
     for (const auto &II : AllLoadsAndStores) {
       Res |= instrumentLoadOrStore(II, DL);
+    }
+
+  // Instrument gather and scatter memory accesses
+  if (ClInstrumentSimd && ClInstrumentMemoryAccesses && SanitizeFunction)
+    for (const auto &II : AllGathersAndScatters) {
+      Res |= instrumentGatherOrScatter(II, DL);
     }
 
   // Instrument atomic memory accesses in any case (they can be used to
@@ -660,6 +700,29 @@ bool ThreadSanitizer::instrumentLoadOrStore(const InstructionInfo &II,
     NumInstrumentedWrites++;
   if (IsCompoundRW || !IsWrite)
     NumInstrumentedReads++;
+  return true;
+}
+
+bool ThreadSanitizer::instrumentGatherOrScatter(Instruction *I,
+                                                const DataLayout &DL) {
+  InstrumentationIRBuilder IRB(I);
+  StringRef FunctionNameRef =
+      dyn_cast<CallInst>(I)->getCalledFunction()->getName();
+  bool IsScatter = FunctionNameRef.contains("scatter");
+  unsigned OperandIdx = IsScatter ? 0 : 3;
+  unsigned NumElements =
+      cast<FixedVectorType>(I->getOperand(OperandIdx)->getType())
+          ->getNumElements();
+  unsigned BytesPerElement =
+      DL.getTypeSizeInBits(I->getOperand(OperandIdx)->getType()) / NumElements /
+      8;
+  FunctionCallee *TsanVector = IsScatter ? TsanVectorScatter : TsanVectorGather;
+  std::vector<Value *> Args{
+      I->getOperand(IsScatter ? 1 : 0),
+      llvm::ConstantInt::get(I->getContext(), llvm::APInt(32, BytesPerElement)),
+      IRB.CreateBitCast(I->getOperand(IsScatter ? 3 : 2), IRB.getInt8Ty())};
+  IRB.CreateCall(TsanVector[NumElements == 4 ? 0 : 1], Args);
+
   return true;
 }
 
@@ -814,8 +877,8 @@ int ThreadSanitizer::getMemoryAccessFuncIndex(Type *OrigTy, Value *Addr,
                                               const DataLayout &DL) {
   assert(OrigTy->isSized());
   uint32_t TypeSize = DL.getTypeStoreSizeInBits(OrigTy);
-  if (TypeSize != 8  && TypeSize != 16 &&
-      TypeSize != 32 && TypeSize != 64 && TypeSize != 128) {
+  if (TypeSize != 8 && TypeSize != 16 && TypeSize != 32 && TypeSize != 64 &&
+      TypeSize != 128 && TypeSize != 256 && TypeSize != 512) {
     NumAccessesWithBadSize++;
     // Ignore all unusual sizes.
     return -1;

--- a/openmp/runtime/src/ompt-specific.cpp
+++ b/openmp/runtime/src/ompt-specific.cpp
@@ -463,6 +463,7 @@ int __ompt_get_task_info_internal(int ancestor_level, int *type,
 }
 
 int __ompt_get_task_memory_internal(void **addr, size_t *size, int blocknum) {
+  *size = 0;
   if (blocknum != 0)
     return 0; // support only a single block
 
@@ -476,22 +477,29 @@ int __ompt_get_task_memory_internal(void **addr, size_t *size, int blocknum) {
   if (taskdata->td_flags.tasktype != TASK_EXPLICIT)
     return 0; // support only explicit task
 
-  void *ret_addr;
-  int64_t ret_size = taskdata->td_size_alloc - sizeof(kmp_taskdata_t);
-
-  // kmp_task_t->data1 is an optional member
-  if (taskdata->td_flags.destructors_thunk)
-    ret_addr = &task->data1 + 1;
-  else
-    ret_addr = &task->part_id + 1;
-
-  ret_size -= (char *)(ret_addr) - (char *)(task);
-  if (ret_size < 0)
+  if (taskdata->td_size_alloc < 0)
     return 0;
 
-  *addr = ret_addr;
-  *size = (size_t)ret_size;
-  return 1;
+  *addr = taskdata;
+  *size = taskdata->td_size_alloc;
+  return 0;
+
+  /*  void *ret_addr;
+    int64_t ret_size = taskdata->td_size_alloc - sizeof(kmp_taskdata_t);
+
+    // kmp_task_t->data1 is an optional member
+    if (taskdata->td_flags.destructors_thunk)
+      ret_addr = &task->data1 + 1;
+    else
+      ret_addr = &task->part_id + 1;
+
+    ret_size -= (char *)(ret_addr) - (char *)(task);
+    if (ret_size < 0)
+      return 0;
+
+    *addr = ret_addr;
+    *size = (size_t)ret_size;
+    return 1;*/
 }
 
 //----------------------------------------------------------

--- a/openmp/runtime/src/ompt-specific.cpp
+++ b/openmp/runtime/src/ompt-specific.cpp
@@ -483,23 +483,6 @@ int __ompt_get_task_memory_internal(void **addr, size_t *size, int blocknum) {
   *addr = taskdata;
   *size = taskdata->td_size_alloc;
   return 0;
-
-  /*  void *ret_addr;
-    int64_t ret_size = taskdata->td_size_alloc - sizeof(kmp_taskdata_t);
-
-    // kmp_task_t->data1 is an optional member
-    if (taskdata->td_flags.destructors_thunk)
-      ret_addr = &task->data1 + 1;
-    else
-      ret_addr = &task->part_id + 1;
-
-    ret_size -= (char *)(ret_addr) - (char *)(task);
-    if (ret_size < 0)
-      return 0;
-
-    *addr = ret_addr;
-    *size = (size_t)ret_size;
-    return 1;*/
 }
 
 //----------------------------------------------------------

--- a/openmp/tools/archer/ompt-tsan.cpp
+++ b/openmp/tools/archer/ompt-tsan.cpp
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <dlfcn.h>
 #include <inttypes.h>
 #include <iostream>
 #include <list>
@@ -29,7 +30,6 @@
 #include <unistd.h>
 #include <unordered_map>
 #include <vector>
-#include <dlfcn.h>
 
 #include "omp-tools.h"
 
@@ -52,7 +52,7 @@
 
 static int hasReductionCallback;
 
-namespace {
+namespace __archer {
 class ArcherFlags {
 public:
 #if (LLVM_VERSION) >= 40
@@ -64,34 +64,50 @@ public:
   int report_data_leak{0};
   int ignore_serial{0};
   std::atomic<int> all_memory{0};
+  int tasking{0};
+  int stack_size{1024};
+  std::atomic<int> untieds{0};
 
   ArcherFlags(const char *env) {
     if (env) {
       std::vector<std::string> tokens;
-      std::string token;
       std::string str(env);
-      std::istringstream iss(str);
-      int tmp_int;
-      while (std::getline(iss, token, ' '))
-        tokens.push_back(token);
+      auto end = str.end();
+      auto it = str.begin();
+      auto is_sep = [](char c) {
+        return c == ' ' || c == ',' || c == ':' || c == '\n' || c == '\t' ||
+               c == '\r';
+      };
+      while (it != end) {
+        auto next_it = std::find_if(it, end, is_sep);
+        tokens.emplace_back(it, next_it);
+        it = next_it;
+        if (it != end) {
+          ++it;
+        }
+      }
 
-      for (std::vector<std::string>::iterator it = tokens.begin();
-           it != tokens.end(); ++it) {
+      int tmp_int = 0;
+      for (const auto &token : tokens) {
 #if (LLVM_VERSION) >= 40
-        if (sscanf(it->c_str(), "flush_shadow=%d", &flush_shadow))
+        if (sscanf(token.c_str(), "flush_shadow=%d", &flush_shadow))
           continue;
 #endif
-        if (sscanf(it->c_str(), "print_max_rss=%d", &print_max_rss))
+        if (sscanf(token.c_str(), "print_max_rss=%d", &print_max_rss))
           continue;
-        if (sscanf(it->c_str(), "verbose=%d", &verbose))
+        if (sscanf(token.c_str(), "verbose=%d", &verbose))
           continue;
-        if (sscanf(it->c_str(), "report_data_leak=%d", &report_data_leak))
+        if (sscanf(token.c_str(), "report_data_leak=%d", &report_data_leak))
           continue;
-        if (sscanf(it->c_str(), "enable=%d", &enabled))
+        if (sscanf(token.c_str(), "enable=%d", &enabled))
           continue;
-        if (sscanf(it->c_str(), "ignore_serial=%d", &ignore_serial))
+        if (sscanf(token.c_str(), "tasking=%d", &tasking))
           continue;
-        if (sscanf(it->c_str(), "all_memory=%d", &tmp_int)) {
+        if (sscanf(token.c_str(), "stack_size=%d", &stack_size))
+          continue;
+        if (sscanf(token.c_str(), "ignore_serial=%d", &ignore_serial))
+          continue;
+        if (sscanf(token.c_str(), "all_memory=%d", &tmp_int)) {
           all_memory = tmp_int;
           continue;
         }
@@ -135,7 +151,9 @@ public:
     }
   }
 };
-} // namespace
+
+static ArcherFlags *archer_flags;
+} // namespace __archer
 
 #if (LLVM_VERSION) >= 40
 extern "C" {
@@ -143,7 +161,6 @@ int __attribute__((weak)) __archer_get_omp_status();
 void __attribute__((weak)) __tsan_flush_memory() {}
 }
 #endif
-static ArcherFlags *archer_flags;
 
 #ifndef TsanHappensBefore
 // Thread Sanitizer is a tool that finds races in code.
@@ -159,6 +176,10 @@ static void (*AnnotateNewMemory)(const char *, int, const volatile void *,
 static void (*__tsan_func_entry)(const void *);
 static void (*__tsan_func_exit)(void);
 static int (*RunningOnValgrind)(void);
+static void *(*__tsan_get_current_fiber)();
+static void *(*__tsan_create_fiber)(unsigned flags);
+static void (*__tsan_destroy_fiber)(void *fiber);
+static void (*__tsan_switch_to_fiber)(void *fiber, unsigned flags);
 }
 
 // This marker is used to define a happens-before arc. The race detector will
@@ -189,9 +210,16 @@ static int (*RunningOnValgrind)(void);
 #define TsanFuncEntry(pc) __tsan_func_entry(pc)
 #define TsanFuncExit() __tsan_func_exit()
 
+// Fibers
+#define TsanGetCurrentFiber() __tsan_get_current_fiber()
+#define TsanCreateFiber(flags) __tsan_create_fiber(flags)
+#define TsanSwitchToFiber(fiber, flags) __tsan_switch_to_fiber(fiber, flags)
+#define TsanDestroyFiber(fiber) __tsan_destroy_fiber(fiber)
+
 /// Required OMPT inquiry functions.
 static ompt_get_parallel_info_t ompt_get_parallel_info;
-static ompt_get_thread_data_t ompt_get_thread_data;
+typedef int (*ompt_get_task_memory_t)(void **addr, size_t *size, int blocknum);
+static ompt_get_task_memory_t ompt_get_task_memory;
 
 typedef char ompt_tsan_clockid;
 
@@ -201,11 +229,11 @@ static uint64_t my_next_id() {
   return ret;
 }
 
-static int pagesize{0};
-
 // Data structure to provide a threadsafe pool of reusable objects.
 // DataPool<Type of objects>
-namespace {
+namespace __archer {
+static int pagesize{0};
+
 template <typename T> struct DataPool final {
   static __thread DataPool<T> *ThreadDataPool;
   std::mutex DPMutex{};
@@ -399,7 +427,7 @@ struct ParallelData final : DataPoolEntry<ParallelData> {
   void *GetBarrierPtr(unsigned Index) { return &(Barrier[Index]); }
 
   ParallelData *Init(const void *codeptr) {
-    codePtr = codeptr;
+    this->codePtr = codeptr;
     return this;
   }
 
@@ -444,6 +472,8 @@ struct Taskgroup final : DataPoolEntry<Taskgroup> {
   Taskgroup(DataPool<Taskgroup> *dp) : DataPoolEntry<Taskgroup>(dp) {}
 };
 
+enum ArcherTaskFlag { ArcherTaskFulfilled = 0x00010000 };
+
 struct TaskData;
 typedef DataPool<TaskData> TaskDataPool;
 template <> __thread TaskDataPool *TaskDataPool::ThreadDataPool = nullptr;
@@ -460,6 +490,9 @@ struct TaskData final : DataPoolEntry<TaskData> {
   /// Child tasks use its address to model omp_all_memory dependencies
   ompt_tsan_clockid AllMemory[2]{0};
 
+  /// Index of which barrier to use next.
+  char BarrierIndex{0};
+
   /// Whether this task is currently executing a barrier.
   bool InBarrier{false};
 
@@ -469,9 +502,10 @@ struct TaskData final : DataPoolEntry<TaskData> {
   /// count execution phase
   int execution{0};
 
-  /// Index of which barrier to use next.
-  char BarrierIndex{0};
+  size_t PrivateDataSize{0};
+  void *PrivateDataAddr{nullptr};
 
+  const void *CodePtr{nullptr};
   /// Count how often this structure has been put into child tasks + 1.
   std::atomic_int RefCount{1};
 
@@ -504,6 +538,13 @@ struct TaskData final : DataPoolEntry<TaskData> {
   int freed{0};
 #endif
 
+  void *Fiber{nullptr};
+
+  void activate() {
+    if (Fiber)
+      TsanSwitchToFiber(Fiber, 1);
+  }
+  void deactivate() { assert(!Fiber || Fiber == TsanGetCurrentFiber()); }
   bool isIncluded() { return TaskType & ompt_task_undeferred; }
   bool isUntied() { return TaskType & ompt_task_untied; }
   bool isFinal() { return TaskType & ompt_task_final; }
@@ -517,6 +558,8 @@ struct TaskData final : DataPoolEntry<TaskData> {
 
   void setAllMemoryDep() { AllMemory[0] = 1; }
   bool hasAllMemoryDep() { return AllMemory[0]; }
+  bool isFulfilled() { return TaskType & ArcherTaskFulfilled; }
+  void setFulfilled() { TaskType |= ArcherTaskFulfilled; }
 
   void *GetTaskPtr() { return &Task; }
 
@@ -525,7 +568,8 @@ struct TaskData final : DataPoolEntry<TaskData> {
   void *GetLastAllMemoryPtr() { return AllMemory; }
   void *GetNextAllMemoryPtr() { return AllMemory + 1; }
 
-  TaskData *Init(TaskData *parent, int taskType) {
+  TaskData *Init(TaskData *parent, int taskType, const void *codePtr) {
+    CodePtr = codePtr;
     TaskType = taskType;
     Parent = parent;
     Team = Parent->Team;
@@ -534,6 +578,8 @@ struct TaskData final : DataPoolEntry<TaskData> {
       // Copy over pointer to taskgroup. This task may set up its own stack
       // but for now belongs to its parent's taskgroup.
       TaskGroup = Parent->TaskGroup;
+      if (archer_flags->tasking && !isIncluded() && !isUntied())
+        Fiber = TsanCreateFiber(0);
     }
     return this;
   }
@@ -543,10 +589,17 @@ struct TaskData final : DataPoolEntry<TaskData> {
     execution = 1;
     ImplicitTask = this;
     Team = team;
+    if (archer_flags->tasking)
+      Fiber = TsanGetCurrentFiber();
     return this;
   }
 
   void Reset() {
+    if (archer_flags->tasking && ImplicitTask != this && Fiber) {
+      TsanDestroyFiber(Fiber);
+    }
+    CodePtr = nullptr;
+    Fiber = nullptr;
     InBarrier = false;
     TaskType = 0;
     execution = 0;
@@ -556,6 +609,8 @@ struct TaskData final : DataPoolEntry<TaskData> {
     ImplicitTask = nullptr;
     Team = nullptr;
     TaskGroup = nullptr;
+    PrivateDataSize = 0;
+    PrivateDataAddr = nullptr;
     if (DependencyMap) {
       for (auto i : *DependencyMap)
         i.second->Delete();
@@ -571,8 +626,9 @@ struct TaskData final : DataPoolEntry<TaskData> {
 #endif
   }
 
-  static TaskData *New(TaskData *parent, int taskType) {
-    return DataPoolEntry<TaskData>::New()->Init(parent, taskType);
+  static TaskData *New(TaskData *parent, int taskType,
+                       const void *codePtr = nullptr) {
+    return DataPoolEntry<TaskData>::New()->Init(parent, taskType, codePtr);
   }
 
   static TaskData *New(ParallelData *team, int taskType) {
@@ -581,10 +637,11 @@ struct TaskData final : DataPoolEntry<TaskData> {
 
   TaskData(DataPool<TaskData> *dp) : DataPoolEntry<TaskData>(dp) {}
 };
-} // namespace
 
 static inline TaskData *ToTaskData(ompt_data_t *task_data) {
-  return reinterpret_cast<TaskData *>(task_data->ptr);
+  if (task_data)
+    return reinterpret_cast<TaskData *>(task_data->ptr);
+  return nullptr;
 }
 
 /// Store a mutex for each wait_id to resolve race condition with callbacks.
@@ -605,6 +662,10 @@ static void ompt_tsan_thread_begin(ompt_thread_t thread_type,
   DependencyDataPool::ThreadDataPool = new DependencyDataPool;
   TsanNewMemory(DependencyDataPool::ThreadDataPool,
                 sizeof(DependencyDataPool::ThreadDataPool));
+  if (archer_flags->tasking) {
+    TsanGetCurrentFiber();
+  }
+
   thread_data->value = my_next_id();
 }
 
@@ -847,19 +908,21 @@ static void ompt_tsan_task_create(
 
     Data = TaskData::New(PData, type);
     new_task_data->ptr = Data;
-  } else if (type & ompt_task_undeferred) {
-    Data = TaskData::New(ToTaskData(parent_task_data), type);
+  } else if (type & ompt_task_explicit || type & ompt_task_target ||
+             type & ompt_task_taskwait) {
+    Data = TaskData::New(ToTaskData(parent_task_data), type, codeptr_ra);
     new_task_data->ptr = Data;
-  } else if (type & ompt_task_explicit || type & ompt_task_target) {
-    Data = TaskData::New(ToTaskData(parent_task_data), type);
-    new_task_data->ptr = Data;
-
-    // Use the newly created address. We cannot use a single address from the
-    // parent because that would declare wrong relationships with other
-    // sibling tasks that may be created before this task is started!
-    TsanHappensBefore(Data->GetTaskPtr());
-    ToTaskData(parent_task_data)->execution++;
+    if (!Data->isIncluded()) {
+      // Use the newly created address. We cannot use a single address from the
+      // parent because that would declare wrong relationships with other
+      // sibling tasks that may be created before this task is started!
+      TsanHappensBefore(Data->GetTaskPtr());
+      ToTaskData(parent_task_data)->execution++;
+    }
   }
+  if (archer_flags->tasking && Data->isUntied() && !archer_flags->untieds++)
+    fprintf(stderr, "Archer Warning: Task-level analysis not yet supported for "
+                    "untied tasks\n");
 }
 
 static void freeTask(TaskData *task) {
@@ -899,6 +962,53 @@ static void acquireDependencies(TaskData *task) {
   }
 }
 
+static void completeTask(TaskData *FromTask, ompt_task_status_t Status,
+                         TaskData *ToTask) {
+  if (!FromTask)
+    return;
+  // Task-end happens after a possible omp_fulfill_event call
+  if (FromTask->isFulfilled())
+    TsanHappensAfter(FromTask->GetTaskPtr());
+  // Included tasks are executed sequentially, no need to track
+  // synchronization
+  if (!FromTask->isIncluded()) {
+    // Task will finish before a barrier in the surrounding parallel region
+    // ...
+    ParallelData *PData = FromTask->Team;
+    TsanHappensBefore(
+        PData->GetBarrierPtr(FromTask->ImplicitTask->BarrierIndex));
+
+    // ... and before an eventual taskwait by the parent thread.
+    TsanHappensBefore(FromTask->Parent->GetTaskwaitPtr());
+
+    if (FromTask->TaskGroup != nullptr) {
+      // This task is part of a taskgroup, so it will finish before the
+      // corresponding taskgroup_end.
+      TsanHappensBefore(FromTask->TaskGroup->GetPtr());
+    }
+  }
+
+  // release dependencies
+  releaseDependencies(FromTask);
+}
+static void switchTasks(TaskData *FromTask, TaskData *ToTask) {
+  if (FromTask)
+    FromTask->deactivate();
+  if (ToTask)
+    ToTask->activate();
+}
+static void endTask(TaskData *FromTask, ompt_task_status_t Status,
+                    TaskData *ToTask) {
+  if (!FromTask)
+    return;
+  if (ompt_get_task_memory) {
+    if (FromTask->PrivateDataSize > 0)
+      TsanNewMemory((/*(void**)*/ FromTask->PrivateDataAddr),
+                    FromTask->PrivateDataSize + 8);
+  }
+  TsanFuncExit();
+}
+
 static void ompt_tsan_task_schedule(ompt_data_t *first_task_data,
                                     ompt_task_status_t prior_task_status,
                                     ompt_data_t *second_task_data) {
@@ -907,10 +1017,13 @@ static void ompt_tsan_task_schedule(ompt_data_t *first_task_data,
   //  The necessary action depends on prior_task_status:
   //
   //    ompt_task_early_fulfill = 5,
-  //     -> ignored
+  //     -> first got fulfill event, second ignored
   //
   //    ompt_task_late_fulfill  = 6,
   //     -> first completed, first freed, second ignored
+  //
+  //    ompt_taskwait_complete = 8,
+  //     -> first starts, first completes, first freed, second ignored
   //
   //    ompt_task_complete      = 1,
   //    ompt_task_cancel        = 3,
@@ -922,57 +1035,67 @@ static void ompt_tsan_task_schedule(ompt_data_t *first_task_data,
   //     -> first suspended, second starts
   //
 
-  if (prior_task_status == ompt_task_early_fulfill)
-    return;
-
   TaskData *FromTask = ToTaskData(first_task_data);
+  TaskData *ToTask = ToTaskData(second_task_data);
 
-  // Legacy handling for missing reduction callback
-  if (hasReductionCallback < ompt_set_always && FromTask->InBarrier) {
-    // We want to ignore writes in the runtime code during barriers,
-    // but not when executing tasks with user code!
-    TsanIgnoreWritesEnd();
+  if (prior_task_status == ompt_task_early_fulfill) {
+    // the omp_fulfill_event call happens before the task can complete
+    TsanHappensBefore(FromTask->GetTaskPtr());
+    FromTask->setFulfilled();
+    return;
   }
 
   // The late fulfill happens after the detached task finished execution
   if (prior_task_status == ompt_task_late_fulfill)
     TsanHappensAfter(FromTask->GetTaskPtr());
 
+  if (prior_task_status == ompt_taskwait_complete)
+    acquireDependencies(FromTask);
+
+  // Legacy handling for missing reduction callback
+  if (hasReductionCallback < ompt_set_always && FromTask &&
+      FromTask->InBarrier) {
+    // We want to ignore writes in the runtime code during barriers,
+    // but not when executing tasks with user code!
+    TsanIgnoreWritesEnd();
+  }
+
   // task completed execution
   if (prior_task_status == ompt_task_complete ||
       prior_task_status == ompt_task_cancel ||
       prior_task_status == ompt_task_late_fulfill) {
-    // Included tasks are executed sequentially, no need to track
-    // synchronization
-    if (!FromTask->isIncluded()) {
-      // Task will finish before a barrier in the surrounding parallel region
-      // ...
-      ParallelData *PData = FromTask->Team;
-      TsanHappensBefore(
-          PData->GetBarrierPtr(FromTask->ImplicitTask->BarrierIndex));
 
-      // ... and before an eventual taskwait by the parent thread.
-      TsanHappensBefore(FromTask->Parent->GetTaskwaitPtr());
+    completeTask(FromTask, prior_task_status, ToTask);
+  }
 
-      if (FromTask->TaskGroup != nullptr) {
-        // This task is part of a taskgroup, so it will finish before the
-        // corresponding taskgroup_end.
-        TsanHappensBefore(FromTask->TaskGroup->GetPtr());
-      }
-    }
+  if (prior_task_status == ompt_task_complete ||
+      prior_task_status == ompt_task_cancel ||
+      prior_task_status == ompt_task_detach) {
 
-    // release dependencies
-    releaseDependencies(FromTask);
+    endTask(FromTask, prior_task_status, ToTask);
+  }
+
+  if (prior_task_status == ompt_task_complete ||
+      prior_task_status == ompt_task_cancel ||
+      prior_task_status == ompt_task_detach ||
+      prior_task_status == ompt_task_switch ||
+      prior_task_status == ompt_task_yield) {
+    // must switch to next task before deleting the previous
+    switchTasks(FromTask, ToTask);
+  }
+
+  if (prior_task_status == ompt_task_complete ||
+      prior_task_status == ompt_task_cancel ||
+      prior_task_status == ompt_task_late_fulfill ||
+      prior_task_status == ompt_taskwait_complete) {
     // free the previously running task
     freeTask(FromTask);
   }
 
-  // For late fulfill of detached task, there is no task to schedule to
-  if (prior_task_status == ompt_task_late_fulfill) {
+  if (!ToTask) {
     return;
   }
 
-  TaskData *ToTask = ToTaskData(second_task_data);
   // Legacy handling for missing reduction callback
   if (hasReductionCallback < ompt_set_always && ToTask->InBarrier) {
     // We re-enter runtime code which currently performs a barrier.
@@ -992,12 +1115,36 @@ static void ompt_tsan_task_schedule(ompt_data_t *first_task_data,
 
   // Handle dependencies on first execution of the task
   if (ToTask->execution == 0) {
+    TsanFuncEntry(ToTask->CodePtr);
+    if (ompt_get_task_memory) {
+      void *addr;
+      size_t size;
+      int ret_task_memory = 0, block = 0;
+      do {
+        size = 0;
+        ret_task_memory = ompt_get_task_memory(&addr, &size, block++);
+        if (size > 0) {
+          TsanNewMemory((/*(void**)*/ addr), size + 8);
+          ToTask->PrivateDataAddr = addr;
+          ToTask->PrivateDataSize = size;
+          //          printf("NewMemory(%p, %zu)\n",addr, size);
+        }
+      } while (ret_task_memory);
+    }
+    if (archer_flags->tasking) {
+      auto stack_size = archer_flags->stack_size;
+      TsanNewMemory((char *)__builtin_frame_address(0) - stack_size,
+                    stack_size);
+    }
     ToTask->execution++;
+    // 1. Task will begin execution after it has been created.
+    TsanHappensAfter(
+        ToTask->GetTaskPtr()); // TODO: after creation, reset clock to creation
     acquireDependencies(ToTask);
+  } else {
+    // 2. Task will resume after it has been switched away.
+    TsanHappensAfter(ToTask->GetTaskPtr());
   }
-  // 1. Task will begin execution after it has been created.
-  // 2. Task will resume after it has been switched away.
-  TsanHappensAfter(ToTask->GetTaskPtr());
 }
 
 static void ompt_tsan_dependences(ompt_data_t *task_data,
@@ -1070,10 +1217,12 @@ static void ompt_tsan_mutex_released(ompt_mutex_t kind, ompt_wait_id_t wait_id,
   Lock.unlock();
 }
 
+} // namespace __archer
+
 // callback , signature , variable to store result , required support level
 #define SET_OPTIONAL_CALLBACK_T(event, type, result, level)                    \
   do {                                                                         \
-    ompt_callback_##type##_t tsan_##event = &ompt_tsan_##event;                \
+    ompt_callback_##type##_t tsan_##event = &__archer::ompt_tsan_##event;      \
     result = ompt_set_callback(ompt_callback_##event,                          \
                                (ompt_callback_t)tsan_##event);                 \
     if (result < level)                                                        \
@@ -1097,11 +1246,12 @@ static void ompt_tsan_mutex_released(ompt_mutex_t kind, ompt_wait_id_t wait_id,
   } while (0)
 
 #define findTsanFunctionSilent(f, fSig) f = fSig dlsym(RTLD_DEFAULT, #f)
+#define findTsanFunctionName(f, name, fSig) f = fSig dlsym(RTLD_DEFAULT, #name)
 
 static int ompt_tsan_initialize(ompt_function_lookup_t lookup, int device_num,
                                 ompt_data_t *tool_data) {
   const char *options = getenv("TSAN_OPTIONS");
-  TsanFlags tsan_flags(options);
+  __archer::TsanFlags tsan_flags(options);
 
   ompt_set_callback_t ompt_set_callback =
       (ompt_set_callback_t)lookup("ompt_set_callback");
@@ -1111,7 +1261,7 @@ static int ompt_tsan_initialize(ompt_function_lookup_t lookup, int device_num,
   }
   ompt_get_parallel_info =
       (ompt_get_parallel_info_t)lookup("ompt_get_parallel_info");
-  ompt_get_thread_data = (ompt_get_thread_data_t)lookup("ompt_get_thread_data");
+  ompt_get_task_memory = (ompt_get_task_memory_t)lookup("ompt_get_task_memory");
 
   if (ompt_get_parallel_info == NULL) {
     fprintf(stderr, "Could not get inquiry function 'ompt_get_parallel_info', "
@@ -1130,6 +1280,10 @@ static int ompt_tsan_initialize(ompt_function_lookup_t lookup, int device_num,
       (void (*)(const char *, int, const volatile void *, size_t)));
   findTsanFunction(__tsan_func_entry, (void (*)(const void *)));
   findTsanFunction(__tsan_func_exit, (void (*)(void)));
+  findTsanFunction(__tsan_create_fiber, (void *(*)(unsigned int)));
+  findTsanFunction(__tsan_destroy_fiber, (void (*)(void *)));
+  findTsanFunction(__tsan_get_current_fiber, (void *(*)()));
+  findTsanFunction(__tsan_switch_to_fiber, (void (*)(void *, unsigned int)));
 
   SET_CALLBACK(thread_begin);
   SET_CALLBACK(thread_end);
@@ -1152,37 +1306,37 @@ static int ompt_tsan_initialize(ompt_function_lookup_t lookup, int device_num,
             "Warning: please export "
             "TSAN_OPTIONS='ignore_noninstrumented_modules=1' "
             "to avoid false positive reports from the OpenMP runtime!\n");
-  if (archer_flags->ignore_serial)
+  if (__archer::archer_flags->ignore_serial)
     TsanIgnoreWritesBegin();
 
   return 1; // success
 }
 
 static void ompt_tsan_finalize(ompt_data_t *tool_data) {
-  if (archer_flags->ignore_serial)
+  if (__archer::archer_flags->ignore_serial)
     TsanIgnoreWritesEnd();
-  if (archer_flags->print_max_rss) {
+  if (__archer::archer_flags->print_max_rss) {
     struct rusage end;
     getrusage(RUSAGE_SELF, &end);
     printf("MAX RSS[KBytes] during execution: %ld\n", end.ru_maxrss);
   }
 
-  if (archer_flags)
-    delete archer_flags;
+  if (__archer::archer_flags)
+    delete __archer::archer_flags;
 }
 
 extern "C" ompt_start_tool_result_t *
 ompt_start_tool(unsigned int omp_version, const char *runtime_version) {
   const char *options = getenv("ARCHER_OPTIONS");
-  archer_flags = new ArcherFlags(options);
-  if (!archer_flags->enabled) {
-    if (archer_flags->verbose)
+  __archer::archer_flags = new __archer::ArcherFlags(options);
+  if (!__archer::archer_flags->enabled) {
+    if (__archer::archer_flags->verbose)
       std::cout << "Archer disabled, stopping operation" << std::endl;
-    delete archer_flags;
+    delete __archer::archer_flags;
     return NULL;
   }
 
-  pagesize = getpagesize();
+  __archer::pagesize = getpagesize();
 
   static ompt_start_tool_result_t ompt_start_tool_result = {
       &ompt_tsan_initialize, &ompt_tsan_finalize, {0}};
@@ -1197,17 +1351,23 @@ ompt_start_tool(unsigned int omp_version, const char *runtime_version) {
   if (!RunningOnValgrind) // if we are not running on TSAN, give a different
                           // tool the chance to be loaded
   {
-    if (archer_flags->verbose)
+    if (__archer::archer_flags->verbose)
       std::cout << "Archer detected OpenMP application without TSan "
                    "stopping operation"
                 << std::endl;
-    delete archer_flags;
+    delete __archer::archer_flags;
     return NULL;
   }
 
-  if (archer_flags->verbose)
-    std::cout << "Archer detected OpenMP application with TSan, supplying "
-                 "OpenMP synchronization semantics"
-              << std::endl;
+  if (__archer::archer_flags->verbose) {
+    if (__archer::archer_flags->tasking)
+      std::cout << "Archer detected OpenMP application with TSan, supplying "
+                   "OpenMP tasking synchronization semantics"
+                << std::endl;
+    else
+      std::cout << "Archer detected OpenMP application with TSan, supplying "
+                   "OpenMP synchronization semantics"
+                << std::endl;
+  }
   return &ompt_start_tool_result;
 }

--- a/openmp/tools/archer/tests/lit.cfg
+++ b/openmp/tools/archer/tests/lit.cfg
@@ -115,7 +115,7 @@ config.substitutions.append(("%libarcher-cxx-compile-and-run", \
 config.substitutions.append(("%libarcher-cxx-compile", \
     "%clang-archerXX %openmp_flags %archer_flags %flags -std=c++17 %s -o %t" + libs))
 config.substitutions.append(("%libarcher-compile", \
-                             "%clang-archer %openmp_flags %archer_flags %flags %s -o %t" + libs))
+                             "%clang-archer %openmp_flags %archer_flags %flags -march=native %s -o %t" + libs))
 config.substitutions.append(("%libarcher-run-race", "%suppression %deflake %t 2>&1 | tee %t.log"))
 config.substitutions.append(("%libarcher-run-nosuppression", "%nosuppression %t 2>&1 | tee %t.log"))
 config.substitutions.append(("%libarcher-run", "%suppression %t 2>&1 | tee %t.log"))

--- a/openmp/tools/archer/tests/parallel/parallel-loop-level-fp.c
+++ b/openmp/tools/archer/tests/parallel/parallel-loop-level-fp.c
@@ -1,0 +1,40 @@
+/*
+ * loop-level.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=dispatch_fibers=1 %libarcher-run | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=dispatch_fibers=1:ignore_serial=1 %libarcher-run | FileCheck %s
+// REQUIRES: tsan
+// XFAIL: *
+#include <omp.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#define NUM_THREADS 2
+
+int main(int argc, char *argv[]) {
+  int vars[NUM_THREADS] = {0};
+  int i;
+  const int len = 10;
+
+#pragma omp parallel for num_threads(NUM_THREADS) shared(vars)                 \
+    schedule(dynamic, 1)
+  for (i = 0; i < len; i++) {
+    vars[omp_get_thread_num()]++;
+  }
+
+  fprintf(stderr, "DONE\n");
+  return 0;
+}
+
+// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: reported
+// CHECK: DONE

--- a/openmp/tools/archer/tests/races/DRB027b-taskdependmissing-orig-yes.c
+++ b/openmp/tools/archer/tests/races/DRB027b-taskdependmissing-orig-yes.c
@@ -1,0 +1,45 @@
+/*
+ * DRB027b-taskdependmissing-orig-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1 %libarcher-run-race | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1:ignore_serial=1 %libarcher-run-race | FileCheck %s
+// REQUIRES: tsan
+#include "ompt/ompt-signal.h"
+#include <assert.h>
+#include <stdio.h>
+
+int main() {
+  int i = 0, sem = 0;
+#pragma omp parallel shared(sem) num_threads(2)
+  {
+#pragma omp masked
+    {
+#pragma omp task
+      {
+        OMPT_SIGNAL(sem);
+        i = 1;
+      }
+#pragma omp task
+      {
+        OMPT_SIGNAL(sem);
+        i = 2;
+      }
+#pragma omp taskwait {}
+    }
+    OMPT_WAIT(sem, 2);
+  }
+  printf("i=%d\n", i);
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/races/DRB131b-taskdep4-orig-omp45-yes.c
+++ b/openmp/tools/archer/tests/races/DRB131b-taskdep4-orig-omp45-yes.c
@@ -1,0 +1,58 @@
+/*
+ * DRB131b-taskdep4-orig-omp45-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1 %libarcher-run-race | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1:ignore_serial=1 %libarcher-run-race | FileCheck %s
+// REQUIRES: tsan
+#include "ompt/ompt-signal.h"
+#include <omp.h>
+#include <stdio.h>
+
+int sem = 0;
+
+void foo() {
+
+  int x = 0, y = 2;
+
+#pragma omp task depend(inout : x) shared(x, sem)
+  {
+    OMPT_SIGNAL(sem);
+    x++; //1st Child Task
+  }
+
+#pragma omp task shared(y, sem)
+  {
+    OMPT_SIGNAL(sem);
+    y--; // 2nd child task
+  }
+
+#pragma omp task depend(in : x) if (0) // 1st taskwait
+  {}
+
+  printf("x=%d\n", x);
+  printf("y=%d\n", y);
+#pragma omp taskwait // 2nd taskwait
+}
+
+int main() {
+#pragma omp parallel
+  {
+#pragma omp masked
+    foo();
+    OMPT_WAIT(sem, 2);
+  }
+
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/races/DRB134b-taskdep5-orig-omp45-yes.c
+++ b/openmp/tools/archer/tests/races/DRB134b-taskdep5-orig-omp45-yes.c
@@ -1,0 +1,58 @@
+/*
+ * DRB134b-taskdep5-orig-omp45-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1 %libarcher-run-race | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1:ignore_serial=1 %libarcher-run-race | FileCheck %s
+// REQUIRES: tsan
+#include "ompt/ompt-signal.h"
+#include <omp.h>
+#include <stdio.h>
+
+int sem = 0;
+
+void foo() {
+  int x = 0, y = 2;
+
+#pragma omp task depend(inout : x) shared(x, sem)
+  {
+    OMPT_SIGNAL(sem);
+    x++; // 1st child task
+  }
+
+#pragma omp task depend(in : x) depend(inout : y) shared(x, y, sem)
+  {
+    OMPT_SIGNAL(sem);
+    y -= x; //2nd child task
+  }
+
+#pragma omp task depend(in : x) if (0) // 1st taskwait
+  {}
+
+  printf("x=%d\n", x);
+  printf("y=%d\n", y);
+
+#pragma omp taskwait // 2nd taskwait
+}
+
+int main() {
+#pragma omp parallel num_threads(2)
+  {
+#pragma omp masked
+    { foo(); }
+    OMPT_WAIT(sem, 2);
+  }
+
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/races/DRB136b-taskdep-mutexinoutset-orig-yes.c
+++ b/openmp/tools/archer/tests/races/DRB136b-taskdep-mutexinoutset-orig-yes.c
@@ -1,0 +1,67 @@
+/*
+ * DRB136b-taskdep-mutexinoutset-orig-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1 %libarcher-run-race | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1:ignore_serial=1 %libarcher-run-race | FileCheck %s
+// REQUIRES: tsan
+#include "ompt/ompt-signal.h"
+#include <omp.h>
+#include <stdio.h>
+
+int main() {
+  int a, b, c, d, sem = 0;
+
+#pragma omp parallel num_threads(2)
+  {
+#pragma omp masked
+    {
+#pragma omp task depend(out : c)
+      {
+        OMPT_SIGNAL(sem);
+        c = 1;
+      }
+#pragma omp task depend(out : a)
+      {
+        OMPT_SIGNAL(sem);
+        a = 2;
+      }
+#pragma omp task depend(out : b)
+      {
+        OMPT_SIGNAL(sem);
+        b = 3;
+      }
+#pragma omp task depend(in : a)
+      {
+        OMPT_SIGNAL(sem);
+        c += a;
+      }
+#pragma omp task depend(in : b)
+      {
+        OMPT_SIGNAL(sem);
+        c += b;
+      }
+#pragma omp task depend(in : c)
+      {
+        OMPT_SIGNAL(sem);
+        d = c;
+      }
+#pragma omp taskwait {}
+    }
+    OMPT_WAIT(sem, 6);
+  }
+
+  printf("%d\n", d);
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/races/DRB165b-taskdep4-orig-omp50-yes.c
+++ b/openmp/tools/archer/tests/races/DRB165b-taskdep4-orig-omp50-yes.c
@@ -1,0 +1,57 @@
+/*
+ * DRB165b-taskdep4-orig-omp50-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1 %libarcher-run-race | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1:ignore_serial=1 %libarcher-run-race | FileCheck %s
+// REQUIRES: tsan
+#include "ompt/ompt-signal.h"
+#include <omp.h>
+#include <stdio.h>
+
+int sem = 0;
+
+void foo() {
+
+  int x = 0, y = 2;
+
+#pragma omp task depend(inout : x) shared(x, sem)
+  {
+    OMPT_SIGNAL(sem);
+    x++; //1st Child Task
+  }
+
+#pragma omp task shared(y, sem)
+  {
+    OMPT_SIGNAL(sem);
+    y--; // 2nd child task
+  }
+
+#pragma omp taskwait depend(in : x) // 1st taskwait
+
+  printf("x=%d\n", x);
+  printf("y=%d\n", y);
+#pragma omp taskwait // 2nd taskwait
+}
+
+int main() {
+#pragma omp parallel
+  {
+#pragma omp masked
+    foo();
+    OMPT_WAIT(sem, 2);
+  }
+
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/races/DRB168b-taskdep5-orig-omp50-yes.c
+++ b/openmp/tools/archer/tests/races/DRB168b-taskdep5-orig-omp50-yes.c
@@ -1,0 +1,56 @@
+/*
+ * DRB168b-taskdep5-orig-omp50-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1 %libarcher-run-race | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1:ignore_serial=1 %libarcher-run-race | FileCheck %s
+// REQUIRES: tsan
+#include "ompt/ompt-signal.h"
+#include <omp.h>
+#include <stdio.h>
+
+int sem = 0;
+
+void foo() {
+  int x = 0, y = 2;
+
+#pragma omp task depend(inout : x) shared(x, sem)
+  {
+    OMPT_SIGNAL(sem);
+    x++; // 1st child task
+  }
+
+#pragma omp task depend(in : x) depend(inout : y) shared(x, y, sem)
+  {
+    OMPT_SIGNAL(sem);
+    y -= x; //2nd child task
+  }
+
+#pragma omp taskwait depend(in : x) // 1st taskwait
+
+  printf("x=%d\n", x);
+  printf("y=%d\n", y);
+#pragma omp taskwait // 2nd taskwait
+}
+
+int main() {
+#pragma omp parallel num_threads(2)
+  {
+#pragma omp masked
+    { foo(); }
+    OMPT_WAIT(sem, 2);
+  }
+
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/races/DRB173b-non-sibling-taskdep-yes.c
+++ b/openmp/tools/archer/tests/races/DRB173b-non-sibling-taskdep-yes.c
@@ -1,0 +1,55 @@
+/*
+ * DRB173b-non-sibling-taskdep-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1 %libarcher-run-race | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1:ignore_serial=1 %libarcher-run-race | FileCheck %s
+// REQUIRES: tsan
+// XFAIL: *
+#include "ompt/ompt-signal.h"
+#include <omp.h>
+#include <stdio.h>
+
+void foo() {
+  int a = 0, sem = 0;
+
+#pragma omp parallel num_threads(2)
+  {
+#pragma omp masked
+#pragma omp taskgroup
+    {
+#pragma omp task depend(inout : a) shared(a)
+      {
+#pragma omp task depend(inout : a) shared(a)
+        OMPT_SIGNAL(sem);
+        a++;
+      }
+
+#pragma omp task depend(inout : a) shared(a)
+      {
+#pragma omp task depend(inout : a) shared(a)
+        OMPT_SIGNAL(sem);
+        a++;
+      }
+    }
+    OMPT_WAIT(sem, 2);
+  }
+  printf("a=%d\n", a);
+}
+
+int main() {
+  foo();
+
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/races/DRB175b-non-sibling-taskdep2-yes.c
+++ b/openmp/tools/archer/tests/races/DRB175b-non-sibling-taskdep2-yes.c
@@ -1,0 +1,43 @@
+/*
+ * DRB175b-non-sibling-taskdep2-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1 %libarcher-run-race | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1:ignore_serial=1 %libarcher-run-race | FileCheck %s
+// REQUIRES: tsan
+#include "ompt/ompt-signal.h"
+#include <omp.h>
+#include <stdio.h>
+
+void foo() {
+  int a = 0, sem = 0;
+
+#pragma omp parallel
+  {
+#pragma omp task depend(inout : a) shared(a)
+    {
+      OMPT_SIGNAL(sem);
+      a++;
+    }
+    if (omp_get_thread_num() != 0)
+      OMPT_WAIT(sem, omp_get_num_threads());
+  }
+  printf("a=%d\n", a);
+}
+
+int main() {
+  foo();
+
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/races/DRB177b-fib-taskdep-yes.c
+++ b/openmp/tools/archer/tests/races/DRB177b-fib-taskdep-yes.c
@@ -1,0 +1,53 @@
+/*
+ * DRB177b-fib-taskdep-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1 %libarcher-run-race | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1:ignore_serial=1 %libarcher-run-race | FileCheck %s
+// REQUIRES: tsan
+#include "ompt/ompt-signal.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int sem = 0;
+
+int fib(int n) {
+  int i, j, s;
+  if (n < 2)
+    return n;
+#pragma omp task shared(i, sem) depend(out : i)
+  { i = fib(n - 1); }
+#pragma omp task shared(j, sem) depend(out : j)
+  { j = fib(n - 2); }
+#pragma omp task shared(i, j, s, sem) depend(in : j)
+  { s = i + j; }
+#pragma omp taskwait
+  return s;
+}
+
+int main(int argc, char **argv) {
+  int n = 10;
+  if (argc > 1)
+    n = atoi(argv[1]);
+#pragma omp parallel
+  {
+#pragma omp masked
+    {
+      printf("fib(%i) = %i\n", n, fib(n));
+      OMPT_SIGNAL(sem);
+    }
+    OMPT_WAIT(sem, 1);
+  }
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/races/parallel-for-antidep-dynamic.c
+++ b/openmp/tools/archer/tests/races/parallel-for-antidep-dynamic.c
@@ -1,0 +1,48 @@
+/*
+ * parallel-for-antidep-dynamic.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=dispatch_fibers=1 %libarcher-run-race | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=dispatch_fibers=1:ignore_serial=1 %libarcher-run-race | FileCheck %s
+// REQUIRES: tsan
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define LEN 6
+
+int main(int argc, char *argv[]) {
+  int indeces[LEN] = {1, 3, 5, 7, 9, 13};
+  double base[26];
+  double *p = base;
+  double *q = p + 12;
+  int i;
+
+  for (i = 1; i < 26; ++i)
+    base[i] = 0.5 * i;
+
+#pragma omp parallel for num_threads(2) schedule(dynamic, 1)
+  for (i = 0; i < LEN; ++i) {
+    int idx = indeces[i];
+    p[idx] += 1.0 + i;
+    q[idx] += 3.0 + i;
+  }
+
+  fprintf(stderr, "DONE.\n");
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK:   Write of size 8
+// CHECK-NEXT: #0 {{.*}}parallel-for-antidep-dynamic.c:3{{4|5}}
+// CHECK:   Previous write of size 8
+// CHECK-NEXT: #0 {{.*}}parallel-for-antidep-dynamic.c:3{{4|5}}
+// CHECK: DONE
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/races/parallel-for-antidep-static.c
+++ b/openmp/tools/archer/tests/races/parallel-for-antidep-static.c
@@ -1,0 +1,49 @@
+/*
+ * parallel-for-antidep-static.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=dispatch_fibers=1 %libarcher-run-race | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=dispatch_fibers=1:ignore_serial=1 %libarcher-run-race | FileCheck %s
+// REQUIRES: tsan
+// XFAIL: *
+#include <stdio.h>
+#include <stdlib.h>
+
+#define LEN 6
+
+int main(int argc, char *argv[]) {
+  int indeces[LEN] = {1, 13, 5, 7, 9, 11};
+  double base[26];
+  double *p = base;
+  double *q = p + 12;
+  int i;
+
+  for (i = 1; i < 26; ++i)
+    base[i] = 0.5 * i;
+
+// Would require 6 threads to manifest race at runtime with static schedule
+#pragma omp parallel for num_threads(2) schedule(static)
+  for (i = 0; i < LEN; ++i) {
+    int idx = indeces[i];
+    p[idx] += 1.0 + i;
+    q[idx] += 3.0 + i;
+  }
+
+  fprintf(stderr, "DONE.\n");
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK:   Write of size 8
+// CHECK-NEXT: #0 {{.*}}parallel-for-antidep-static.c:3{{4|5}}
+// CHECK:   Previous write of size 8
+// CHECK-NEXT: #0 {{.*}}parallel-for-antidep-static.c:3{{4|5}}
+// CHECK: DONE
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/races/parallel-for-antidep.c
+++ b/openmp/tools/archer/tests/races/parallel-for-antidep.c
@@ -1,0 +1,44 @@
+/*
+ * parallel-for-antidep.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=dispatch_fibers=1 %libarcher-run-race | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=dispatch_fibers=1:ignore_serial=1 %libarcher-run-race | FileCheck %s
+// REQUIRES: tsan
+
+#include <stdio.h>
+
+int main(int argc,char *argv[]) {
+  int i, j, len = 20; 
+  double a[len][len];
+
+  for (i = 0; i < len; ++i)
+    for (j = 0; j < len; ++j)
+      a[i][j] = i * j; 
+
+#pragma omp parallel for private(j)
+  for (i = 0; i < len - 1; ++i) {
+    for (j = 0; j < len ; ++j) {
+      a[i][j] += a[i + 1][j];
+    }
+  }
+
+  fprintf(stderr, "DONE.\n");
+  return 0;
+}
+
+// CHECK: WARNING: ThreadSanitizer: data race
+// CHECK:   {{(Write|Read)}} of size 8
+// CHECK-NEXT: #0 {{.*}}parallel-for-antidep.c:30
+// CHECK:   Previous {{write|read}} of size 8
+// CHECK-NEXT: #0 {{.*}}parallel-for-antidep.c:30
+// CHECK: DONE
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/races/parallel-for-array-reduction-no-barrier.c
+++ b/openmp/tools/archer/tests/races/parallel-for-array-reduction-no-barrier.c
@@ -14,24 +14,29 @@
 // Number of threads is empirical: We need enough (>4) threads so that
 // the reduction is really performed hierarchically in the barrier!
 
-// RUN: env OMP_NUM_THREADS=3 %libarcher-compile-and-run| FileCheck %s
-// RUN: env OMP_NUM_THREADS=7 %libarcher-compile-and-run| FileCheck %s
+// RUN: env OMP_NUM_THREADS=3 %libarcher-compile-and-run-race | FileCheck %s
+// RUN: env OMP_NUM_THREADS=7 %libarcher-compile-and-run-race | FileCheck %s
 
 // REQUIRES: tsan
 #include <omp.h>
 #include <stdio.h>
 
 int main(int argc, char *argv[]) {
-  int var = 0;
+  int var[10]={0,1,2,3,4,5,6,7,8,9};
   
-#pragma omp parallel reduction(+ : var)
-  { var = 1; }
-
+#pragma omp parallel
+  {
+#pragma omp masked
+    var[5] = 23;
+#pragma omp for reduction(+ : var)
+    for (int i = 0; i < 1000; i++)
+      { var[i%10]++; }
+  }
   fprintf(stderr, "DONE\n");
-  int error = (var != omp_get_max_threads());
+  int error = (var[5] != 123);
   return error;
 }
 
-// CHECK-NOT: ThreadSanitizer: data race
-// CHECK-NOT: ThreadSanitizer: reported
+// CHECK: ThreadSanitizer: data race
 // CHECK: DONE
+// CHECK: ThreadSanitizer: reported

--- a/openmp/tools/archer/tests/races/parallel-for-array-reduction-nowait.c
+++ b/openmp/tools/archer/tests/races/parallel-for-array-reduction-nowait.c
@@ -14,24 +14,29 @@
 // Number of threads is empirical: We need enough (>4) threads so that
 // the reduction is really performed hierarchically in the barrier!
 
-// RUN: env OMP_NUM_THREADS=3 %libarcher-compile-and-run| FileCheck %s
-// RUN: env OMP_NUM_THREADS=7 %libarcher-compile-and-run| FileCheck %s
+// RUN: env OMP_NUM_THREADS=3 %libarcher-compile-and-run-race | FileCheck %s
+// RUN: env OMP_NUM_THREADS=7 %libarcher-compile-and-run-race | FileCheck %s
 
 // REQUIRES: tsan
 #include <omp.h>
 #include <stdio.h>
 
 int main(int argc, char *argv[]) {
-  int var = 0;
+  int var[10]={0,1,2,3,4,5,6,7,8,9};
   
-#pragma omp parallel reduction(+ : var)
-  { var = 1; }
-
+#pragma omp parallel
+  {
+#pragma omp for reduction(+ : var) nowait
+    for (int i = 0; i < 1000; i++)
+      { var[i%10]++; }
+#pragma omp masked
+    var[5] += 23;
+  }
   fprintf(stderr, "DONE\n");
-  int error = (var != omp_get_max_threads());
+  int error = (var[5] != 123);
   return error;
 }
 
-// CHECK-NOT: ThreadSanitizer: data race
-// CHECK-NOT: ThreadSanitizer: reported
+// CHECK: ThreadSanitizer: data race
 // CHECK: DONE
+// CHECK: ThreadSanitizer: reported

--- a/openmp/tools/archer/tests/races/parallel-for-reduction-no-barrier.c
+++ b/openmp/tools/archer/tests/races/parallel-for-reduction-no-barrier.c
@@ -14,8 +14,8 @@
 // Number of threads is empirical: We need enough (>4) threads so that
 // the reduction is really performed hierarchically in the barrier!
 
-// RUN: env OMP_NUM_THREADS=3 %libarcher-compile-and-run| FileCheck %s
-// RUN: env OMP_NUM_THREADS=7 %libarcher-compile-and-run| FileCheck %s
+// RUN: env OMP_NUM_THREADS=3 %libarcher-compile-and-run-race | FileCheck %s
+// RUN: env OMP_NUM_THREADS=7 %libarcher-compile-and-run-race | FileCheck %s
 
 // REQUIRES: tsan
 #include <omp.h>
@@ -24,14 +24,19 @@
 int main(int argc, char *argv[]) {
   int var = 0;
   
-#pragma omp parallel reduction(+ : var)
-  { var = 1; }
-
+#pragma omp parallel
+  {
+#pragma omp masked
+    var = 23;
+#pragma omp for reduction(+ : var)
+    for (int i = 0; i < 100; i++)
+      { var++; }
+  }
   fprintf(stderr, "DONE\n");
-  int error = (var != omp_get_max_threads());
+  int error = (var != 123);
   return error;
 }
 
-// CHECK-NOT: ThreadSanitizer: data race
-// CHECK-NOT: ThreadSanitizer: reported
+// CHECK: ThreadSanitizer: data race
 // CHECK: DONE
+// CHECK: ThreadSanitizer: reported

--- a/openmp/tools/archer/tests/races/parallel-for-reduction-nowait.c
+++ b/openmp/tools/archer/tests/races/parallel-for-reduction-nowait.c
@@ -14,8 +14,8 @@
 // Number of threads is empirical: We need enough (>4) threads so that
 // the reduction is really performed hierarchically in the barrier!
 
-// RUN: env OMP_NUM_THREADS=3 %libarcher-compile-and-run| FileCheck %s
-// RUN: env OMP_NUM_THREADS=7 %libarcher-compile-and-run| FileCheck %s
+// RUN: env OMP_NUM_THREADS=3 %libarcher-compile-and-run-race | FileCheck %s
+// RUN: env OMP_NUM_THREADS=7 %libarcher-compile-and-run-race | FileCheck %s
 
 // REQUIRES: tsan
 #include <omp.h>
@@ -24,14 +24,19 @@
 int main(int argc, char *argv[]) {
   int var = 0;
   
-#pragma omp parallel reduction(+ : var)
-  { var = 1; }
-
+#pragma omp parallel
+  {
+#pragma omp for reduction(+ : var) nowait
+    for (int i = 0; i < 100; i++)
+      { var++; }
+#pragma omp masked
+    var = 23;
+  }
   fprintf(stderr, "DONE\n");
-  int error = (var != omp_get_max_threads());
+  int error = (var != 123);
   return error;
 }
 
-// CHECK-NOT: ThreadSanitizer: data race
-// CHECK-NOT: ThreadSanitizer: reported
+// CHECK: ThreadSanitizer: data race
 // CHECK: DONE
+// CHECK: ThreadSanitizer: reported

--- a/openmp/tools/archer/tests/reduction/parallel-for-array-reduction-barrier.c
+++ b/openmp/tools/archer/tests/reduction/parallel-for-array-reduction-barrier.c
@@ -22,13 +22,21 @@
 #include <stdio.h>
 
 int main(int argc, char *argv[]) {
-  int var = 0;
+  int var[10]={0,1,2,3,4,5,6,7,8,9};
   
-#pragma omp parallel reduction(+ : var)
-  { var = 1; }
-
+#pragma omp parallel
+  {
+#pragma omp masked
+    var[5] = 23;
+#pragma omp barrier
+#pragma omp for reduction(+ : var)
+    for (int i = 0; i < 1000; i++)
+      { var[i%10]++; }
+#pragma omp masked
+    var[4] += 42;
+  }
   fprintf(stderr, "DONE\n");
-  int error = (var != omp_get_max_threads());
+  int error = (var[5] != 23+100) || (var[4] != 4+100+42);
   return error;
 }
 

--- a/openmp/tools/archer/tests/reduction/parallel-for-reduction-barrier.c
+++ b/openmp/tools/archer/tests/reduction/parallel-for-reduction-barrier.c
@@ -24,11 +24,19 @@
 int main(int argc, char *argv[]) {
   int var = 0;
   
-#pragma omp parallel reduction(+ : var)
-  { var = 1; }
-
+#pragma omp parallel
+  {
+#pragma omp masked
+    var = 23;
+#pragma omp barrier
+#pragma omp for reduction(+ : var)
+    for (int i = 0; i < 100; i++)
+      { var++; }
+#pragma omp masked
+    var += 42;
+  }
   fprintf(stderr, "DONE\n");
-  int error = (var != omp_get_max_threads());
+  int error = (var != 23+100+42);
   return error;
 }
 

--- a/openmp/tools/archer/tests/reduction/parallel-reduction-nowait.c
+++ b/openmp/tools/archer/tests/reduction/parallel-reduction-nowait.c
@@ -37,6 +37,7 @@ int main(int argc, char *argv[]) {
   }
 
   fprintf(stderr, "DONE\n");
+  printf("var = %i\n", var);
   int error = (var != 100);
   return error;
 }

--- a/openmp/tools/archer/tests/simd/simd-broadcast-no.c
+++ b/openmp/tools/archer/tests/simd/simd-broadcast-no.c
@@ -1,0 +1,44 @@
+/*
+ * simd-broadcast-no.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile -DTYPE=float && %libarcher-run | FileCheck %s
+// RUN: %libarcher-compile -DTYPE=double && %libarcher-run | FileCheck %s
+// REQUIRES: tsan
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef TYPE
+#define TYPE double
+#endif /*TYPE*/
+
+int main(int argc, char *argv[]) {
+  int len = 20000;
+  if (argc > 1)
+    len = atoi(argv[1]);
+  double a[len];
+  for (int i = 0; i < len; i++)
+    a[i] = i;
+  TYPE c = M_PI;
+
+#pragma omp parallel for simd num_threads(2) schedule(dynamic, 64)
+  for (int i = 0; i < len; i++)
+    a[i] = a[i] + c;
+
+  fprintf(stderr, "DONE\n");
+  return 0;
+}
+
+// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: reported
+// CHECK: DONE

--- a/openmp/tools/archer/tests/simd/simd-broadcast-yes.c
+++ b/openmp/tools/archer/tests/simd/simd-broadcast-yes.c
@@ -1,0 +1,55 @@
+/*
+ * simd-broadcast-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile -DTYPE=float && %libarcher-run-race | FileCheck
+// --check-prefix=FLOAT %s RUN: %libarcher-compile -DTYPE=double &&
+// %libarcher-run-race | FileCheck --check-prefix=DOUBLE %s REQUIRES: tsan
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef TYPE
+#define TYPE double
+#endif /*TYPE*/
+
+int main(int argc, char *argv[]) {
+  int len = 20000;
+  if (argc > 1)
+    len = atoi(argv[1]);
+  TYPE a[len];
+  for (int i = 0; i < len; i++)
+    a[i] = i;
+  double c = M_PI;
+
+#pragma omp parallel for simd num_threads(2) schedule(dynamic, 64)
+  for (int i = 0; i < len; i++)
+    a[i] = a[i] + a[64];
+
+  fprintf(stderr, "DONE\n");
+  return 0;
+}
+
+// FLOAT: WARNING: ThreadSanitizer: data race
+// FLOAT-NEXT:   {{(Write|Read)}} of size {{(4|8)}}
+// FLOAT-NEXT: #0 {{.*}}simd-broadcast-yes.c
+// FLOAT:   Previous {{(read|write)}} of size {{(4|8)}}
+// FLOAT-NEXT: #0 {{.*}}simd-broadcast-yes.c
+
+// DOUBLE: WARNING: ThreadSanitizer: data race
+// DOUBLE-NEXT:   {{(Write|Read)}} of size 8
+// DOUBLE-NEXT: #0 {{.*}}simd-broadcast-yes.c
+// DOUBLE:   Previous {{(read|write)}} of size 8
+// DOUBLE-NEXT: #0 {{.*}}simd-broadcast-yes.c
+
+// CHECK: DONE
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/simd/simd-gather-yes.c
+++ b/openmp/tools/archer/tests/simd/simd-gather-yes.c
@@ -1,0 +1,63 @@
+/*
+ * simd-gather-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile -DTYPE=float -DSIMDLEN=4 && %libarcher-run-race | FileCheck --check-prefix=FLOAT %s
+// RUN: %libarcher-compile -DTYPE=float -DSIMDLEN=8 && %libarcher-run-race | FileCheck --check-prefix=FLOAT %s
+// RUN: %libarcher-compile -DTYPE=double -DSIMDLEN=4 && %libarcher-run-race | FileCheck --check-prefix=DOUBLE %s
+// RUN: %libarcher-compile -DTYPE=double -DSIMDLEN=8 && %libarcher-run-race | FileCheck --check-prefix=DOUBLE %s
+// REQUIRES: tsan
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef TYPE
+#define TYPE double
+#endif /*TYPE*/
+
+#ifndef SIMDLEN
+#define SIMDLEN 8
+#endif /*SIMDLEN*/
+
+int main(int argc, char *argv[]) {
+  int len = 20000;
+
+  if (argc > 1)
+    len = atoi(argv[1]);
+  TYPE a[2 * len], b[len];
+
+  for (int i = 0; i < 2 * len; i++)
+    a[i] = i;
+  for (int i = 0; i < len; i++)
+    b[i] = i + 1;
+
+#pragma omp parallel for simd schedule(dynamic, 64) simdlen(SIMDLEN)
+  for (int i = 0; i < len; i++)
+    a[i + 64] = a[i * 2] + b[i];
+
+  printf("DONE\n");
+  return 0;
+}
+
+// FLOAT: WARNING: ThreadSanitizer: data race
+// FLOAT-NEXT:   {{(Write|Read)}} of size {{(4|8)}}
+// FLOAT-NEXT: #0 {{.*}}simd-gather-yes.c
+// FLOAT:   Previous {{(read|write)}} of size {{(4|8)}}
+// FLOAT-NEXT: #0 {{.*}}simd-gather-yes.c
+
+// DOUBLE: WARNING: ThreadSanitizer: data race
+// DOUBLE-NEXT:   {{(Write|Read)}} of size 8
+// DOUBLE-NEXT: #0 {{.*}}simd-gather-yes.c
+// DOUBLE:   Previous {{(read|write)}} of size 8
+// DOUBLE-NEXT: #0 {{.*}}simd-gather-yes.c
+
+// CHECK: DONE
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/simd/simd-gatherscatter-no.c
+++ b/openmp/tools/archer/tests/simd/simd-gatherscatter-no.c
@@ -1,0 +1,46 @@
+/*
+ * simd-gatherscatter-no.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile -DTYPE=float && %libarcher-run | FileCheck %s
+// RUN: %libarcher-compile -DTYPE=double && %libarcher-run | FileCheck %s
+// REQUIRES: tsan
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef TYPE
+#define TYPE double
+#endif /*TYPE*/
+
+int main(int argc, char *argv[]) {
+  int len = 20000;
+
+  if (argc > 1)
+    len = atoi(argv[1]);
+  TYPE a[2 * len], b[len];
+
+  for (int i = 0; i < 2 * len; i++)
+    a[i] = i;
+  for (int i = 0; i < len; i++)
+    b[i] = i + 1;
+
+#pragma omp parallel for simd schedule(dynamic, 64)
+  for (int i = 0; i < len; i++)
+    a[i * 2] = a[i * 2] + b[i];
+
+  fprintf(stderr, "DONE\n");
+  return 0;
+}
+
+// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: reported
+// CHECK: DONE

--- a/openmp/tools/archer/tests/simd/simd-loadstore-no.c
+++ b/openmp/tools/archer/tests/simd/simd-loadstore-no.c
@@ -1,0 +1,46 @@
+/*
+ * simd-loadstore-no.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile -DTYPE=float && %libarcher-run | FileCheck %s
+// RUN: %libarcher-compile -DTYPE=double && %libarcher-run | FileCheck %s
+// REQUIRES: tsan
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef TYPE
+#define TYPE double
+#endif /*TYPE*/
+
+int main(int argc, char *argv[]) {
+  int len = 20000;
+
+  if (argc > 1)
+    len = atoi(argv[1]);
+  TYPE a[len], b[len];
+
+  for (int i = 0; i < len; i++) {
+    a[i] = i;
+    b[i] = i + 1;
+  }
+
+#pragma omp parallel for simd schedule(dynamic, 64)
+  for (int i = 0; i < len; i++)
+    a[i] = a[i] + b[i];
+
+  fprintf(stderr, "DONE\n");
+  return 0;
+}
+
+// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: reported
+// CHECK: DONE

--- a/openmp/tools/archer/tests/simd/simd-loadstore-yes.c
+++ b/openmp/tools/archer/tests/simd/simd-loadstore-yes.c
@@ -1,0 +1,57 @@
+/*
+ * simd-loadstore-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile -DTYPE=float && %libarcher-run-race | FileCheck --check-prefix=FLOAT %s
+// RUN: %libarcher-compile -DTYPE=double && %libarcher-run-race | FileCheck --check-prefix=DOUBLE %s
+// REQUIRES: tsan
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef TYPE
+#define TYPE double
+#endif /*TYPE*/
+
+int main(int argc, char *argv[]) {
+  int len = 20000;
+
+  if (argc > 1)
+    len = atoi(argv[1]);
+  double a[len], b[len];
+
+  for (int i = 0; i < len; i++) {
+    a[i] = i;
+    b[i] = i + 1;
+  }
+
+#pragma omp parallel for simd schedule(dynamic, 64)
+  for (int i = 0; i < len - 64; i++)
+    a[i + 64] = a[i] + b[i];
+
+  fprintf(stderr, "DONE\n");
+  return 0;
+}
+
+// FLOAT: WARNING: ThreadSanitizer: data race
+// FLOAT-NEXT:   {{(Write|Read)}} of size {{(4|8)}}
+// FLOAT-NEXT: #0 {{.*}}simd-loadstore-yes.c
+// FLOAT:   Previous {{(read|write)}} of size {{(4|8)}}
+// FLOAT-NEXT: #0 {{.*}}simd-loadstore-yes.c
+
+// DOUBLE: WARNING: ThreadSanitizer: data race
+// DOUBLE-NEXT:   {{(Write|Read)}} of size 8
+// DOUBLE-NEXT: #0 {{.*}}simd-loadstore-yes.c
+// DOUBLE:   Previous {{(read|write)}} of size 8
+// DOUBLE-NEXT: #0 {{.*}}simd-loadstore-yes.c
+
+// CHECK: DONE
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/simd/simd-scatter-yes.c
+++ b/openmp/tools/archer/tests/simd/simd-scatter-yes.c
@@ -1,0 +1,63 @@
+/*
+ * simd-scatter-yes.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile -DTYPE=float -DSIMDLEN=4 && %libarcher-run-race | FileCheck --check-prefix=FLOAT %s
+// RUN: %libarcher-compile -DTYPE=float -DSIMDLEN=8 && %libarcher-run-race | FileCheck --check-prefix=FLOAT %s
+// RUN: %libarcher-compile -DTYPE=double -DSIMDLEN=4 && %libarcher-run-race | FileCheck --check-prefix=DOUBLE %s
+// RUN: %libarcher-compile -DTYPE=double -DSIMDLEN=8 && %libarcher-run-race | FileCheck --check-prefix=DOUBLE %s
+// REQUIRES: tsan
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifndef TYPE
+#define TYPE double
+#endif /*TYPE*/
+
+#ifndef SIMDLEN
+#define SIMDLEN 8
+#endif /*SIMDLEN*/
+
+int main(int argc, char *argv[]) {
+  int len = 20000;
+
+  if (argc > 1)
+    len = atoi(argv[1]);
+  TYPE a[2 * len], b[len];
+
+  for (int i = 0; i < 2 * len; i++)
+    a[i] = i;
+  for (int i = 0; i < len; i++)
+    b[i] = i + 1;
+
+#pragma omp parallel for simd schedule(dynamic, 64) simdlen(SIMDLEN)
+  for (int i = 0; i < len; i++)
+    a[i * 2] = a[i + 64] + b[i];
+
+  fprintf(stderr, "DONE\n");
+  return 0;
+}
+
+// FLOAT: WARNING: ThreadSanitizer: data race
+// FLOAT-NEXT:   {{(Write|Read)}} of size {{(4|8)}}
+// FLOAT-NEXT: #0 {{.*}}simd-scatter-yes.c
+// FLOAT:   Previous {{(read|write)}} of size {{(4|8)}}
+// FLOAT-NEXT: #0 {{.*}}simd-scatter-yes.c
+
+// DOUBLE: WARNING: ThreadSanitizer: data race
+// DOUBLE-NEXT:   {{(Write|Read)}} of size 8
+// DOUBLE-NEXT: #0 {{.*}}simd-scatter-yes.c
+// DOUBLE:   Previous {{(read|write)}} of size 8
+// DOUBLE-NEXT: #0 {{.*}}simd-scatter-yes.c
+
+// CHECK: DONE
+// CHECK: ThreadSanitizer: reported {{[0-9]+}} warnings

--- a/openmp/tools/archer/tests/task/DRB132b-taskdep4-orig-omp45-no.c
+++ b/openmp/tools/archer/tests/task/DRB132b-taskdep4-orig-omp45-no.c
@@ -1,0 +1,62 @@
+/*
+ * DRB132b-taskdep4-orig-omp45-no.c -- Archer testcase
+ */
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+//
+// See tools/archer/LICENSE.txt for details.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1 %libarcher-run | FileCheck %s
+// RUN: %libarcher-compile && env ARCHER_OPTIONS=tasking=1:ignore_serial=1 %libarcher-run | FileCheck %s
+// REQUIRES: tsan
+#include "ompt/ompt-signal.h"
+#include <omp.h>
+#include <stdio.h>
+
+int sem = 0;
+
+void foo() {
+
+  int x = 0, y = 2;
+
+#pragma omp task depend(inout : x) shared(x, sem)
+  {
+    OMPT_SIGNAL(sem);
+    x++; //1st Child Task
+  }
+
+#pragma omp task shared(y, sem)
+  {
+    OMPT_SIGNAL(sem);
+    y--; // 2nd child task
+  }
+
+#pragma omp task depend(in : x) if (0) // 1st taskwait
+  {}
+
+  printf("x=%d\n", x);
+
+#pragma omp taskwait // 2nd taskwait
+
+  printf("y=%d\n", y);
+}
+
+int main() {
+#pragma omp parallel
+  {
+#pragma omp masked
+    foo();
+    OMPT_WAIT(sem, 2);
+  }
+
+  fprintf(stderr, "DONE.\n");
+  return 0;
+}
+
+// CHECK-NOT: ThreadSanitizer: data race
+// CHECK-NOT: ThreadSanitizer: reported
+// CHECK: DONE


### PR DESCRIPTION
Detailed description available in the individual commit messages.

Improvements:
- reduce runtime overhead for concurrent reads from high number of threads
- task-centric data race analysis (`ARCHER_OPTIONS=tasking=1`)
- loop-level data race analysis (e.g., `ARCHER_OPTIONS=dispatch=13`)
- enables data race detection for vectorized code (e.g., AVX2/AVX512)
- enable detection of certain data races in combination with OpenMP reductions